### PR TITLE
fix: add redis init container iamge tag

### DIFF
--- a/templates/attack-deployment.yml
+++ b/templates/attack-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: attack-init-redis
-          image: redis
+          image: redis:6-alpine
           command:
             [
               "sh",

--- a/templates/blender-deployment.yml
+++ b/templates/blender-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: blender-init-redis
-          image: redis
+          image: redis:6-alpine
           command:
             [
               "sh",

--- a/templates/core-deployment.yml
+++ b/templates/core-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: core-init-redis
-          image: redis
+          image: redis:6-alpine
           command:
             [
               "sh",

--- a/templates/transformer-deployment.yml
+++ b/templates/transformer-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
         - name: transformer-init-redis
-          image: redis
+          image: redis:6-alpine
           command:
             [
               "sh",


### PR DESCRIPTION
if you omit the imagePullPolicy field, and you don't specify the tag for the container image, imagePullPolicy is automatically set to Always;
if you omit the imagePullPolicy field, and you don't specify the tag for the container image that isn't :latest, the imagePullPolicy is automatically set to IfNotPresent.

https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting