### PR TITLE
perf/reduce-resources-limit

### DIFF
--- a/templates/attack-deployment.yml
+++ b/templates/attack-deployment.yml
@@ -35,7 +35,7 @@ spec:
               value: "redis://redis.$(NAMESPACE).svc.cluster.local:6379/0"
           command: ["./attack"]
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "100m"
           ports:

--- a/templates/blender-deployment.yml
+++ b/templates/blender-deployment.yml
@@ -37,7 +37,7 @@ spec:
               value: "core.$(NAMESPACE).svc.cluster.local:50005"
           command: ["./blender"]
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "100m"
           ports:

--- a/templates/captain-deployment.yml
+++ b/templates/captain-deployment.yml
@@ -83,7 +83,7 @@ spec:
                   name: capt-minio-secret
                   key: capt-minio-password
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "500m"
           ports:

--- a/templates/core-deployment.yml
+++ b/templates/core-deployment.yml
@@ -84,7 +84,7 @@ spec:
                   name: core-minio-secret
                   key: core-minio-password
           resources:
-            limits:
+            requests:
               memory: "256Mi"
               cpu: "500m"
           ports:

--- a/templates/deployment-matcher.yml
+++ b/templates/deployment-matcher.yml
@@ -46,7 +46,7 @@ spec:
               value: "core.$(NAMESPACE).svc.cluster.local:50005"
           command: ["npm", "start"]
           resources:
-            limits:
+            requests:
               memory: "256Mi"
               cpu: "200m"
           ports:

--- a/templates/exploitmgr-deployment.yml
+++ b/templates/exploitmgr-deployment.yml
@@ -47,7 +47,7 @@ spec:
             - name: CORE_URL
               value: "core.$(NAMESPACE).svc.cluster.local:50005"
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "100m"
           ports:

--- a/templates/redis-deployment.yml
+++ b/templates/redis-deployment.yml
@@ -17,7 +17,7 @@ spec:
         - name: redis
           image: redis:6-alpine
           resources:
-            limits:
+            requests:
               memory: "256Mi"
               cpu: "200m"
           ports:

--- a/templates/template-deployment.yml
+++ b/templates/template-deployment.yml
@@ -49,7 +49,7 @@ spec:
             - name: EXPLOITMGR_URL
               value: "exploitmgr.$(NAMESPACE).svc.cluster.local:50005"
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "100m"
           ports:

--- a/templates/transformer-deployment.yml
+++ b/templates/transformer-deployment.yml
@@ -37,7 +37,7 @@ spec:
               value: "core.$(NAMESPACE).svc.cluster.local:50005"
           command: ["./transformer"]
           resources:
-            limits:
+            requests:
               memory: "128Mi"
               cpu: "100m"
           ports:


### PR DESCRIPTION
* perf: reduce resources limit

> if a Container specifies its own CPU limit, but does not specify a CPU request, Kubernetes automatically assigns a CPU request that matches the limit. [1]

In this case, we may need `resources.requests` instead of `resources.limits`.
According to the above, change to specifies the resources requests.

[1] https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits