### PR TITLE
ci: add chart lint

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,13 +23,5 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-
       - name: Run chart-testing (lint)
         run: ct lint


### PR DESCRIPTION
Add GitHub Action for installing the [helm/chart-testing](https://github.com/helm/chart-testing) CLI tool.