### PR TITLE
feat/default internal db

### DIFF
--- a/charts/agh2/README.md
+++ b/charts/agh2/README.md
@@ -47,7 +47,7 @@ helm install agh2 lkclab/agh2
 
 | Name                               | Description                              | Value                  |
 | ---------------------------------- | ---------------------------------------- | ---------------------- |
-| `db.connection.type`               | Choose to use external DB or internal DB | `external`             |
+| `db.connection.type`               | Choose to use external DB or internal DB | `internal`             |
 | `db.connection.driver`             | Database driver                          | `postgresql`           |
 | `db.connection.host`               | Database host address                    | `database.example.com` |
 | `db.connection.port`               | Database host port                       | `5432`                 |
@@ -66,7 +66,7 @@ Leave as default if using external DB
 | -------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------- |
 | `postgresql.enabled`                         | Enable internal database                                      | `true`                                         |
 | `postgresql.image.repository`                | Internal database image repository                            | `leukocyte-lab/postgresql`                     |
-| `postgresql.image.tag`                       | Internal database image tag (immutable tags are recommended)  | `v0.1.0-postgres-15.1.0-pgroonga-2.4.2-debian` |
+| `postgresql.image.tag`                       | Internal database image tag (immutable tags are recommended)  | `v0.1.2-postgres-15.1.0-pgroonga-2.4.2-debian` |
 | `postgresql.image.pullPolicy`                | Internal database image pull policy                           | `IfNotPresent`                                 |
 | `postgresql.image.pullSecrets`               | Specify docker-registry secret names as an array              | `[]`                                           |
 | `postgresql.auth.username`                   | Internal database initial user                                | `argushack`                                    |
@@ -82,9 +82,9 @@ Leave as default if using external DB
 
 | Name                        | Description                              | Value                  |
 | --------------------------- | ---------------------------------------- | ---------------------- |
-| `minio.connection.type`     | Choose to use external DB or internal DB | `external`             |
+| `minio.connection.type`     | Choose to use external DB or internal DB | `internal`             |
 | `minio.connection.host`     | Database host address                    | `database.example.com` |
-| `minio.connection.port`     | Database host port                       | `5432`                 |
+| `minio.connection.port`     | Database host port                       | `9000`                 |
 | `minio.connection.user`     | Database user                            | `argushack`            |
 | `minio.connection.password` | Database password                        | `""`                   |
 | `minio.secret.enabled`      | Enable minio secret generation           | `true`                 |
@@ -97,7 +97,7 @@ Leave as default if using external DB
 
 | Name                              | Description                                               | Value                         |
 | --------------------------------- | --------------------------------------------------------- | ----------------------------- |
-| `minio.internal.enabled`          | Enable internal minio                                     | `false`                       |
+| `minio.internal.enabled`          | Enable internal minio                                     | `true`                        |
 | `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnami/minio`        |
 | `minio.image.tag`                 | Internal MinIO image tag (immutable tags are recommended) | `2022.12.2-debian-11-r0`      |
 | `minio.image.pullPolicy`          | Internal MinIO image pull policy                          | `IfNotPresent`                |
@@ -132,7 +132,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-ATTACK
 | --------------------------------------- | -------------------------------------------------------------- | ------------------------------------------ |
 | `attack.enabled`                        | Enable ATTACK module                                           | `true`                                     |
 | `attack.image.repository`               | ATTACK image repository                                        | `leukocyte-lab/argushack2/attack`          |
-| `attack.image.tag`                      | ATTACK image tag (immutable tags are recommended)              | `v0.9.0`                                   |
+| `attack.image.tag`                      | ATTACK image tag (immutable tags are recommended)              | `v0.10.0`                                  |
 | `attack.image.pullPolicy`               | ATTACK image pull policy                                       | `IfNotPresent`                             |
 | `attack.image.pullSecrets`              | Specify docker-registry secret names as an array               | `[]`                                       |
 | `attack.secret.enabled`                 | Enable secret generate for ATTACK                              | `true`                                     |
@@ -144,10 +144,10 @@ ref: https://github.com/Leukocyte-Lab/AGH2-ATTACK
 | `attack.service`                        | ATTACK service parameters                                      |                                            |
 | `attack.service.group.enabled`          | Enable ATTACK Group worker                                     | `true`                                     |
 | `attack.service.group.image.repository` | ATTACK Group worker image repository                           | `leukocyte-lab/argushack2/group`           |
-| `attack.service.group.image.tag`        | ATTACK Group worker image tag (immutable tags are recommended) | `v1.3.6`                                   |
+| `attack.service.group.image.tag`        | ATTACK Group worker image tag (immutable tags are recommended) | `v1.3.7`                                   |
 | `attack.service.ui.enabled`             | Enable ATTACK UI                                               | `true`                                     |
 | `attack.service.ui.image.repository`    | ATTACK UI image repository                                     | `leukocyte-lab/argushack2/attack-frontend` |
-| `attack.service.ui.image.tag`           | ATTACK UI image tag (immutable tags are recommended)           | `v0.3.0`                                   |
+| `attack.service.ui.image.tag`           | ATTACK UI image tag (immutable tags are recommended)           | `v0.3.1`                                   |
 | `attack.service.ui.image.pullPolicy`    | ATTACK UI image pull policy                                    | `IfNotPresent`                             |
 | `attack.service.ui.image.pullSecrets`   | Specify docker-registry secret names as an array               | `[]`                                       |
 | `attack.service.redis.enabled`          | Enable redis                                                   | `true`                                     |
@@ -161,7 +161,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Blender
 
 | Name                            | Description                                        | Value                              |
 | ------------------------------- | -------------------------------------------------- | ---------------------------------- |
-| `blender.enabled`               | Enable Blender module                              | `true`                             |
+| `blender.enabled`               | Enable Blender module                              | `false`                            |
 | `blender.image.repository`      | Blender image repository                           | `leukocyte-lab/argushack2/blender` |
 | `blender.image.tag`             | Blender image tag (immutable tags are recommended) | `v1.1.0`                           |
 | `blender.image.pullPolicy`      | Blender image pull policy                          | `IfNotPresent`                     |
@@ -180,7 +180,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Captain
 | ------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------- |
 | `captain.enabled`                                 | Enable Captain module                                     | `true`                                    |
 | `captain.image.repository`                        | Captain image repository                                  | `leukocyte-lab/argushack2/captain`        |
-| `captain.image.tag`                               | Captain image tag (immutable tags are recommended)        | `v0.19.0`                                 |
+| `captain.image.tag`                               | Captain image tag (immutable tags are recommended)        | `v0.20.1-rc.0`                            |
 | `captain.image.pullPolicy`                        | Captain image pull policy                                 | `IfNotPresent`                            |
 | `captain.image.pullSecrets`                       | Specify docker-registry secret names as an array          | `[]`                                      |
 | `captain.secret.enabled`                          | Enable secret generate for Captain                        | `true`                                    |
@@ -220,7 +220,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Core
 | ------------------------------ | ------------------------------------------------ | ------------------------------- |
 | `core.enabled`                 | Enable Core module                               | `true`                          |
 | `core.image.repository`        | Core image repository                            | `leukocyte-lab/argushack2/core` |
-| `core.image.tag`               | Core image tag (immutable tags are recommended)  | `v1.17.0`                       |
+| `core.image.tag`               | Core image tag (immutable tags are recommended)  | `v1.18.1-rc.0`                  |
 | `core.image.pullPolicy`        | Core image pull policy                           | `IfNotPresent`                  |
 | `core.image.pullSecrets`       | Specify docker-registry secret names as an array | `[]`                            |
 | `core.secret.enabled`          | Enable secret generate for Core                  | `true`                          |
@@ -249,7 +249,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Exploit-Manager
 | ------------------------------------ | ---------------------------------------------------------- | ------------------------------------- |
 | `exploitmgr.enabled`                 | Enable Exploit-Manager module                              | `true`                                |
 | `exploitmgr.image.repository`        | Exploit-Manager image repository                           | `leukocyte-lab/argushack2/exploitmgr` |
-| `exploitmgr.image.tag`               | Exploit-Manager image tag (immutable tags are recommended) | `v0.12.0`                             |
+| `exploitmgr.image.tag`               | Exploit-Manager image tag (immutable tags are recommended) | `v0.14.0-rc.0`                        |
 | `exploitmgr.image.pullPolicy`        | Exploit-Manager image pull policy                          | `IfNotPresent`                        |
 | `exploitmgr.image.pullSecrets`       | Specify docker-registry secret names as an array           | `[]`                                  |
 | `exploitmgr.secret.enabled`          | Enable secret generate for Exploit-Manager                 | `true`                                |
@@ -274,7 +274,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Matcher
 
 | Name                        | Description                                        | Value                              |
 | --------------------------- | -------------------------------------------------- | ---------------------------------- |
-| `matcher.enabled`           | Enable Matcher module                              | `true`                             |
+| `matcher.enabled`           | Enable Matcher module                              | `false`                            |
 | `matcher.image.repository`  | Matcher image repository                           | `leukocyte-lab/argushack2/matcher` |
 | `matcher.image.tag`         | Matcher image tag (immutable tags are recommended) | `v1.2.2`                           |
 | `matcher.image.pullPolicy`  | Matcher image pull policy                          | `IfNotPresent`                     |
@@ -289,7 +289,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Template
 
 | Name                               | Description                                         | Value                               |
 | ---------------------------------- | --------------------------------------------------- | ----------------------------------- |
-| `template.enabled`                 | Enable Template module                              | `true`                              |
+| `template.enabled`                 | Enable Template module                              | `false`                             |
 | `template.image.repository`        | Template image repository                           | `leukocyte-lab/argushack2/template` |
 | `template.image.tag`               | Template image tag (immutable tags are recommended) | `v0.2.5`                            |
 | `template.image.pullPolicy`        | Template image pull policy                          | `IfNotPresent`                      |
@@ -314,7 +314,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Transformer
 
 | Name                                | Description                                            | Value                                  |
 | ----------------------------------- | ------------------------------------------------------ | -------------------------------------- |
-| `transformer.enabled`               | Enable Transformer module                              | `true`                                 |
+| `transformer.enabled`               | Enable Transformer module                              | `false`                                |
 | `transformer.image.repository`      | Transformer image repository                           | `leukocyte-lab/argushack2/transformer` |
 | `transformer.image.tag`             | Transformer image tag (immutable tags are recommended) | `v1.1.0`                               |
 | `transformer.image.pullPolicy`      | Transformer image pull policy                          | `IfNotPresent`                         |
@@ -333,7 +333,7 @@ ref: https://github.com/Leukocyte-Lab/AGH2-UI
 | ---------------------- | ------------------------------------------------ | ----------------------------------- |
 | `ui.enabled`           | Enable UI module                                 | `true`                              |
 | `ui.image.repository`  | UI image repository                              | `leukocyte-lab/argushack2/frontend` |
-| `ui.image.tag`         | UI image tag (immutable tags are recommended)    | `v2.19.0`                           |
+| `ui.image.tag`         | UI image tag (immutable tags are recommended)    | `v2.20.1`                           |
 | `ui.image.pullPolicy`  | UI image pull policy                             | `IfNotPresent`                      |
 | `ui.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                                |
 | `ui.extraEnv`          | UI additional environment variables              | `{}`                                |

--- a/charts/agh2/README.md
+++ b/charts/agh2/README.md
@@ -25,7 +25,6 @@ helm install agh2 lkclab/agh2
 | Name                                 | Description                                       | Value                  |
 | ------------------------------------ | ------------------------------------------------- | ---------------------- |
 | `customRegistrySecret.enabled`       | Enable custom registry secret generation          | `true`                 |
-| `customRegistrySecret.secretName`    | Name of the generated secret                      | `lkc-registry`         |
 | `customRegistrySecret.auth.registry` | URL of the registry server                        | `registry.lkc-lab.com` |
 | `customRegistrySecret.auth.username` | Username to authenticate with the registry server | `""`                   |
 | `customRegistrySecret.auth.password` | Password to authenticate with the registry server | `""`                   |
@@ -137,7 +136,6 @@ ref: https://github.com/Leukocyte-Lab/AGH2-ATTACK
 | `attack.image.pullSecrets`              | Specify docker-registry secret names as an array               | `[]`                                       |
 | `attack.secret.enabled`                 | Enable secret generate for ATTACK                              | `true`                                     |
 | `attack.secret.db.enabled`              | Enable secret generate for DB                                  | `true`                                     |
-| `attack.secret.db.secretName`           | Secret name for Captain DB                                     | `attack-db-secret`                         |
 | `attack.secret.db.name`                 | Database name                                                  | `attack-db`                                |
 | `attack.secret.db.user`                 | Database user                                                  | `""`                                       |
 | `attack.secret.db.password`             | Database password                                              | `""`                                       |
@@ -185,7 +183,6 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Captain
 | `captain.image.pullSecrets`                       | Specify docker-registry secret names as an array          | `[]`                                      |
 | `captain.secret.enabled`                          | Enable secret generate for Captain                        | `true`                                    |
 | `captain.secret.db.enabled`                       | Enable secret generate for Captain database               | `true`                                    |
-| `captain.secret.db.secretName`                    | Secret name for Captain DB                                | `capt-db-secret`                          |
 | `captain.secret.db.name`                          | Database name                                             | `captain-db`                              |
 | `captain.secret.db.user`                          | Database user                                             | `""`                                      |
 | `captain.secret.db.password`                      | Database password                                         | `""`                                      |
@@ -225,7 +222,6 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Core
 | `core.image.pullSecrets`       | Specify docker-registry secret names as an array | `[]`                            |
 | `core.secret.enabled`          | Enable secret generate for Core                  | `true`                          |
 | `core.secret.db.enabled`       | Enable secret generate for Core database         | `true`                          |
-| `core.secret.db.secretName`    | Secret name for Core DB                          | `core-db-secret`                |
 | `core.secret.db.name`          | Database name                                    | `core-db`                       |
 | `core.secret.db.user`          | Database user                                    | `""`                            |
 | `core.secret.db.password`      | Database password                                | `""`                            |
@@ -245,26 +241,21 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Core
 Exploit-Manager module for AGH2.
 ref: https://github.com/Leukocyte-Lab/AGH2-Exploit-Manager
 
-| Name                                 | Description                                                | Value                                 |
-| ------------------------------------ | ---------------------------------------------------------- | ------------------------------------- |
-| `exploitmgr.enabled`                 | Enable Exploit-Manager module                              | `true`                                |
-| `exploitmgr.image.repository`        | Exploit-Manager image repository                           | `leukocyte-lab/argushack2/exploitmgr` |
-| `exploitmgr.image.tag`               | Exploit-Manager image tag (immutable tags are recommended) | `v0.14.0-rc.0`                        |
-| `exploitmgr.image.pullPolicy`        | Exploit-Manager image pull policy                          | `IfNotPresent`                        |
-| `exploitmgr.image.pullSecrets`       | Specify docker-registry secret names as an array           | `[]`                                  |
-| `exploitmgr.secret.enabled`          | Enable secret generate for Exploit-Manager                 | `true`                                |
-| `exploitmgr.secret.db.enabled`       | Enable secret generate for Exploit-Manager database        | `true`                                |
-| `exploitmgr.secret.db.secretName`    | Secret name for Exploit-Manager DB                         | `exploitmgr-db-secret`                |
-| `exploitmgr.secret.db.name`          | Database name                                              | `exploitmgr-db`                       |
-| `exploitmgr.secret.db.user`          | Database user                                              | `""`                                  |
-| `exploitmgr.secret.db.password`      | Database password                                          | `""`                                  |
-| `exploitmgr.secret.minio.enabled`    | Enable secret generate for Minio                           | `true`                                |
-| `exploitmgr.secret.minio.secretName` | Secret name for Minio                                      | `exploitmgr-minio-secret`             |
-| `exploitmgr.secret.minio.user`       | Minio user                                                 | `""`                                  |
-| `exploitmgr.secret.minio.password`   | Minio password                                             | `""`                                  |
-| `exploitmgr.service`                 | Exploit-Manager service parameters                         |                                       |
-| `exploitmgr.service.redis.enabled`   | Enable redis                                               | `true`                                |
-| `exploitmgr.extraEnv`                | Exploit-Manager additional environment variables           | `{}`                                  |
+| Name                               | Description                                                | Value                                 |
+| ---------------------------------- | ---------------------------------------------------------- | ------------------------------------- |
+| `exploitmgr.enabled`               | Enable Exploit-Manager module                              | `true`                                |
+| `exploitmgr.image.repository`      | Exploit-Manager image repository                           | `leukocyte-lab/argushack2/exploitmgr` |
+| `exploitmgr.image.tag`             | Exploit-Manager image tag (immutable tags are recommended) | `v0.14.0-rc.0`                        |
+| `exploitmgr.image.pullPolicy`      | Exploit-Manager image pull policy                          | `IfNotPresent`                        |
+| `exploitmgr.image.pullSecrets`     | Specify docker-registry secret names as an array           | `[]`                                  |
+| `exploitmgr.secret.enabled`        | Enable secret generate for Exploit-Manager                 | `true`                                |
+| `exploitmgr.secret.db.enabled`     | Enable secret generate for Exploit-Manager database        | `true`                                |
+| `exploitmgr.secret.db.name`        | Database name                                              | `exploitmgr-db`                       |
+| `exploitmgr.secret.db.user`        | Database user                                              | `""`                                  |
+| `exploitmgr.secret.db.password`    | Database password                                          | `""`                                  |
+| `exploitmgr.service`               | Exploit-Manager service parameters                         |                                       |
+| `exploitmgr.service.redis.enabled` | Enable redis                                               | `true`                                |
+| `exploitmgr.extraEnv`              | Exploit-Manager additional environment variables           | `{}`                                  |
 
 
 ### AGH2-Matcher parameters
@@ -296,7 +287,6 @@ ref: https://github.com/Leukocyte-Lab/AGH2-Template
 | `template.image.pullSecrets`       | Specify docker-registry secret names as an array    | `[]`                                |
 | `template.secret.enabled`          | Enable secret generate for Template                 | `true`                              |
 | `template.secret.db.enabled`       | Enable secret generate for Template database        | `true`                              |
-| `template.secret.db.secretName`    | Secret name for Template DB                         | `template-db-secret`                |
 | `template.secret.db.name`          | Database name                                       | `template-db`                       |
 | `template.secret.db.user`          | Database user                                       | `""`                                |
 | `template.secret.db.password`      | Database password                                   | `""`                                |

--- a/charts/agh2/templates/_helpers.tpl
+++ b/charts/agh2/templates/_helpers.tpl
@@ -70,7 +70,16 @@ Usage:
 {{- define "connection-string" -}}
 
 {{- $iDBHost := printf "db.%v.svc.cluster.local" .context.Release.Namespace }}
-{{- $connStr := printf "%v://%v:%v@%v:%v/%v" (required "db.connection.driver is required, set it or provide individually when use as macro function." .db.driver) (required "db.connection.user is required, set it or provide individually when use as macro function." .db.user) (required "db.connection.password is required, set it or provide individually when use as macro function." .db.password) (eq .db.type "internal" | ternary $iDBHost (required "db.connection.host is required, set it or provide individually when use as macro function." .db.host)) (required "db.connection.port is required, set it or provide individually when use as macro function." .db.port) (required "db.name is required, provide individually when use as macro function." .db.name) }}
+{{- $connStr := printf "%v://%v:%v@%v:%v/%v"
+  (required "db.connection.driver is required, set it or provide individually when use as macro function." .db.driver)
+  (required "db.connection.user is required, set it or provide individually when use as macro function." .db.user)
+  (required "db.connection.password is required, set it or provide individually when use as macro function." .db.password)
+  (eq .db.type "internal" | ternary $iDBHost
+    (required "db.connection.host is required, set it or provide individually when use as macro function." .db.host)
+  )
+  (required "db.connection.port is required, set it or provide individually when use as macro function." .db.port)
+  (required "db.name is required, provide individually when use as macro function." .db.name)
+}}
 
 {{- if and .db.options (default .db.options.disableSSL true) }}
   {{- printf "%v?sslmode=disable" $connStr | b64enc | quote }}

--- a/charts/agh2/templates/_helpers.tpl
+++ b/charts/agh2/templates/_helpers.tpl
@@ -65,10 +65,13 @@ Create the name of the service account to use
 {{/*
 Return DB connection string
 Usage:
-{{ include "connection-string" (dict "db" (merge .Values.path.to.secret.db .Values.db.connection)) }}
+{{ include "connection-string" (dict "db" (merge .Values.path.to.secret.db .Values.db.connection) "context" $) }}
 */}}
 {{- define "connection-string" -}}
-{{- $connStr := printf "%v://%v:%v@%v:%v/%v" .db.driver .db.user .db.password .db.host .db.port .db.name }}
+
+{{- $iDBHost := printf "db.%v.svc.cluster.local" .context.Release.Namespace }}
+{{- $connStr := printf "%v://%v:%v@%v:%v/%v" .db.driver .db.user .db.password (eq .db.type "internal" | ternary $iDBHost .db.host) .db.port .db.name }}
+
 {{- if and .db.options (default .disableSSL true) }}
   {{- printf "%v?sslmode=disable" $connStr | b64enc | quote }}
 {{- else }}

--- a/charts/agh2/templates/_helpers.tpl
+++ b/charts/agh2/templates/_helpers.tpl
@@ -72,7 +72,7 @@ Usage:
 {{- $iDBHost := printf "db.%v.svc.cluster.local" .context.Release.Namespace }}
 {{- $connStr := printf "%v://%v:%v@%v:%v/%v" .db.driver .db.user .db.password (eq .db.type "internal" | ternary $iDBHost .db.host) .db.port .db.name }}
 
-{{- if and .db.options (default .disableSSL true) }}
+{{- if and .db.options (default .db.options.disableSSL true) }}
   {{- printf "%v?sslmode=disable" $connStr | b64enc | quote }}
 {{- else }}
   {{- printf $connStr | b64enc | quote }}

--- a/charts/agh2/templates/_helpers.tpl
+++ b/charts/agh2/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Usage:
 {{- define "connection-string" -}}
 
 {{- $iDBHost := printf "db.%v.svc.cluster.local" .context.Release.Namespace }}
-{{- $connStr := printf "%v://%v:%v@%v:%v/%v" .db.driver .db.user .db.password (eq .db.type "internal" | ternary $iDBHost .db.host) .db.port .db.name }}
+{{- $connStr := printf "%v://%v:%v@%v:%v/%v" (required "db.connection.driver is required, set it or provide individually when use as macro function." .db.driver) (required "db.connection.user is required, set it or provide individually when use as macro function." .db.user) (required "db.connection.password is required, set it or provide individually when use as macro function." .db.password) (eq .db.type "internal" | ternary $iDBHost (required "db.connection.host is required, set it or provide individually when use as macro function." .db.host)) (required "db.connection.port is required, set it or provide individually when use as macro function." .db.port) (required "db.name is required, provide individually when use as macro function." .db.name) }}
 
 {{- if and .db.options (default .db.options.disableSSL true) }}
   {{- printf "%v?sslmode=disable" $connStr | b64enc | quote }}

--- a/charts/agh2/templates/attack/attack-db-secret.yml
+++ b/charts/agh2/templates/attack/attack-db-secret.yml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
-  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.attack.secret.db .Values.db.connection)) }}
+  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.attack.secret.db .Values.db.connection) "context" $) }}
 {{- end }}

--- a/charts/agh2/templates/captain/captain-db-secret.yml
+++ b/charts/agh2/templates/captain/captain-db-secret.yml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
-  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.captain.secret.db .Values.db.connection)) }}
+  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.captain.secret.db .Values.db.connection) "context" $) }}
 {{- end }}

--- a/charts/agh2/templates/captain/captain-minio-secret.yml
+++ b/charts/agh2/templates/captain/captain-minio-secret.yml
@@ -7,7 +7,7 @@ metadata:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
   {{- with .Values.captain.secret.minio }}
-  capt-minio-user: {{ printf .user | b64enc | quote }}
-  capt-minio-password: {{ printf .password | b64enc | quote }}
+  capt-minio-user: {{ printf (required "captain.secret.minio.user is required" .user) | b64enc | quote }}
+  capt-minio-password: {{ printf (required "captain.secret.minio.password is required" .password) | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/agh2/templates/core/core-db-secret.yml
+++ b/charts/agh2/templates/core/core-db-secret.yml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
-  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.core.secret.db .Values.db.connection)) }}
+  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.core.secret.db .Values.db.connection) "context" $) }}
 {{- end }}

--- a/charts/agh2/templates/core/core-minio-secret.yml
+++ b/charts/agh2/templates/core/core-minio-secret.yml
@@ -7,7 +7,7 @@ metadata:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
   {{- with .Values.core.secret.minio }}
-  core-minio-user: {{ printf .user | b64enc | quote }}
-  core-minio-password: {{ printf .password | b64enc | quote }}
+  capt-minio-user: {{ printf (required "core.secret.minio.user is required" .user) | b64enc | quote }}
+  capt-minio-password: {{ printf (required "core.secret.minio.password is required" .password) | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/agh2/templates/exploit-manager/exploitmgr-db-secret.yml
+++ b/charts/agh2/templates/exploit-manager/exploitmgr-db-secret.yml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
-  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.exploitmgr.secret.db .Values.db.connection)) }}
+  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.exploitmgr.secret.db .Values.db.connection) "context" $) }}
 {{- end }}

--- a/charts/agh2/templates/template/template-db-secret.yml
+++ b/charts/agh2/templates/template/template-db-secret.yml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "AGH2.labels" . | nindent 4 }}
 data:
-  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.template.secret.db .Values.db.connection)) }}
+  DB_CONN_STR: {{ include "connection-string" (dict "db" (merge .Values.template.secret.db .Values.db.connection) "context" $) }}
 {{- end }}

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -555,12 +555,6 @@ exploitmgr:
   ## @param exploitmgr.extraEnv Exploit-Manager additional environment variables
   ##
   extraEnv: {}
-# frontend:
-#   enabled: true
-#   image:
-#     repository: registry.lkc-lab.com/leukocyte-lab/argushack2/frontend
-#     tag: v2.18.2
-#     pullPolicy: IfNotPresent
 
 ## @section AGH2-Matcher parameters
 ## @descriptionStart

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -545,16 +545,6 @@ exploitmgr:
       name: exploitmgr-db
       user: ""
       password: ""
-    ## @param exploitmgr.secret.minio.enabled Enable secret generate for Minio
-    ## @param exploitmgr.secret.minio.secretName Secret name for Minio
-    ## @param exploitmgr.secret.minio.user Minio user
-    ## @param exploitmgr.secret.minio.password Minio password
-    ##
-    minio:
-      enabled: true
-      secretName: exploitmgr-minio-secret
-      user: ""
-      password: ""
   ## @extra exploitmgr.service Exploit-Manager service parameters
   ##
   service:

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -62,13 +62,13 @@ db:
     ## internal` or `external` in string
     ## Set `db.image` when internal is in use
     ##
-    type: external
+    type: internal
     ## @param db.connection.driver Database driver
     ##
     driver: postgresql
     ## @param db.connection.host Database host address
     ## IP or FQDN in string
-    ## Required if `db.type` is external
+    ## Required if `db.type` is external, ignored if internal
     ##
     host: database.example.com
     ## @param db.connection.port Database host port
@@ -113,7 +113,7 @@ postgresql:
   ##
   image:
     repository: leukocyte-lab/postgresql
-    tag: v0.1.0-postgres-15.1.0-pgroonga-2.4.2-debian
+    tag: v0.1.2-postgres-15.1.0-pgroonga-2.4.2-debian
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param postgresql.auth.username Internal database initial user
@@ -144,16 +144,16 @@ minio:
     ## internal` or `external` in string
     ## Set `minio.image` when internal is in use
     ##
-    type: external
+    type: internal
     ## @param minio.connection.host Database host address
     ## IP or FQDN in string
-    ## Required if `minio.type` is external
+    ## Required if `minio.type` is external, ignored if internal
     ##
     host: database.example.com
     ## @param minio.connection.port Database host port
     ## Port in number
     ##
-    port: 5432
+    port: 9000
     ## @param minio.connection.user Database user
     ## DB User in string
     ##
@@ -176,7 +176,7 @@ minio:
   internal:
     ## @param minio.internal.enabled Enable internal minio
     ##
-    enabled: false
+    enabled: true
   ## @skip minio.fullnameOverride
   ##
   fullnameOverride: minio # remapping chart bitnami/minio -> minio
@@ -266,7 +266,7 @@ attack:
   ##
   image:
     repository: leukocyte-lab/argushack2/attack
-    tag: v0.9.0
+    tag: v0.10.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param attack.secret.enabled Enable secret generate for ATTACK
@@ -333,7 +333,7 @@ attack:
 blender:
   ## @param blender.enabled Enable Blender module
   ##
-  enabled: true
+  enabled: false
   ## @param blender.image.repository Blender image repository
   ## @param blender.image.tag Blender image tag (immutable tags are recommended)
   ## @param blender.image.pullPolicy Blender image pull policy
@@ -581,7 +581,7 @@ exploitmgr:
 matcher:
   ## @param matcher.enabled Enable Matcher module
   ##
-  enabled: true
+  enabled: false
   ## @param matcher.image.repository Matcher image repository
   ## @param matcher.image.tag Matcher image tag (immutable tags are recommended)
   ## @param matcher.image.pullPolicy Matcher image pull policy
@@ -605,7 +605,7 @@ matcher:
 template:
   ## @param template.enabled Enable Template module
   ##
-  enabled: true
+  enabled: false
   ## @param template.image.repository Template image repository
   ## @param template.image.tag Template image tag (immutable tags are recommended)
   ## @param template.image.pullPolicy Template image pull policy
@@ -655,7 +655,7 @@ template:
 transformer:
   ## @param transformer.enabled Enable Transformer module
   ##
-  enabled: true
+  enabled: false
   ## @param transformer.image.repository Transformer image repository
   ## @param transformer.image.tag Transformer image tag (immutable tags are recommended)
   ## @param transformer.image.pullPolicy Transformer image pull policy

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -22,7 +22,9 @@ global:
 ##
 
 ## @param customRegistrySecret.enabled Enable custom registry secret generation
-## @param customRegistrySecret.secretName Name of the generated secret
+## @skip customRegistrySecret.secretName
+## Name of the generated secret
+## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
 ##
 customRegistrySecret:
   enabled: true
@@ -274,14 +276,17 @@ attack:
   secret:
     enabled: true # Manually create secret named as the value of `attack.secret.name` if set to false
     ## @param attack.secret.db.enabled Enable secret generate for DB
-    ## @param attack.secret.db.secretName Secret name for Captain DB
     ## @param attack.secret.db.name Database name
     ## @param attack.secret.db.user Database user
     ## @param attack.secret.db.password Database password
     ##
     db:
-      enabled: true
+      ## @skip attack.secret.db.secretName
+      ## Secret name for Captain DB
+      ## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
+      ##
       secretName: attack-db-secret
+      enabled: true
       name: attack-db
       user: ""
       password: ""
@@ -380,14 +385,17 @@ captain:
   secret:
     enabled: true # Manually create secrets named as the value of `captain.secret.name` if set to false
     ## @param captain.secret.db.enabled Enable secret generate for Captain database
-    ## @param captain.secret.db.secretName Secret name for Captain DB
     ## @param captain.secret.db.name Database name
     ## @param captain.secret.db.user Database user
     ## @param captain.secret.db.password Database password
     ##
     db:
-      enabled: true
+      ## @skip captain.secret.db.secretName
+      ## Secret name for Captain DB
+      ## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
+      ##
       secretName: capt-db-secret
+      enabled: true
       name: captain-db
       user: ""
       password: ""
@@ -472,14 +480,17 @@ core:
   secret:
     enabled: true # Manually create secrets named as the value of `core.secret.name` if set to false
     ## @param core.secret.db.enabled Enable secret generate for Core database
-    ## @param core.secret.db.secretName Secret name for Core DB
     ## @param core.secret.db.name Database name
     ## @param core.secret.db.user Database user
     ## @param core.secret.db.password Database password
     ##
     db:
-      enabled: true
+      ## @skip core.secret.db.secretName
+      ## Secret name for Core DB
+      ## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
+      ##
       secretName: core-db-secret
+      enabled: true
       name: core-db
       user: ""
       password: ""
@@ -534,14 +545,17 @@ exploitmgr:
   secret:
     enabled: true # Manually create secrets named as the value of `exploitmgr.secret.name` if set to false
     ## @param exploitmgr.secret.db.enabled Enable secret generate for Exploit-Manager database
-    ## @param exploitmgr.secret.db.secretName Secret name for Exploit-Manager DB
     ## @param exploitmgr.secret.db.name Database name
     ## @param exploitmgr.secret.db.user Database user
     ## @param exploitmgr.secret.db.password Database password
     ##
     db:
-      enabled: true
+      ## @skip exploitmgr.secret.db.secretName
+      ## Secret name for Exploit-Manager DB
+      ## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
+      ##
       secretName: expmgr-db-secret
+      enabled: true
       name: exploitmgr-db
       user: ""
       password: ""
@@ -605,14 +619,17 @@ template:
   secret:
     enabled: true # Manually create secrets named as the value of `template.secret.name` if set to false
     ## @param template.secret.db.enabled Enable secret generate for Template database
-    ## @param template.secret.db.secretName Secret name for Template DB
     ## @param template.secret.db.name Database name
     ## @param template.secret.db.user Database user
     ## @param template.secret.db.password Database password
     ##
     db:
-      enabled: true
+      ## @skip template.secret.db.secretName
+      ## Secret name for Template DB
+      ## !!! DO NOT CHANGE IF YOU DON'T KNOW WHAT YOU ARE DOING !!!
+      ##
       secretName: template-db-secret
+      enabled: true
       name: template-db
       user: ""
       password: ""

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -541,7 +541,7 @@ exploitmgr:
     ##
     db:
       enabled: true
-      secretName: exploitmgr-db-secret
+      secretName: expmgr-db-secret
       name: exploitmgr-db
       user: ""
       password: ""


### PR DESCRIPTION
- chores: Modify default values.
- feat: DB connection string support auto fallback on internal mode.
- feat: Use new spec of macro function `connection-string`.
- fix: Wrong handling db connection options.
- perf: Mark db fields as required.
- style: Change line for easier to read.
