### PR TITLE
feat: Use liveness probe to perform health check on endpoints.

### DIFF
--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -120,6 +120,14 @@ spec:
             {{- if .Values.captain.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.captain.extraEnv "context" $) | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               memory: "128Mi"

--- a/charts/agh3/templates/controller/controller-deployment.yml
+++ b/charts/agh3/templates/controller/controller-deployment.yml
@@ -75,6 +75,14 @@ spec:
             {{- if .Values.controller.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraEnv "context" $) | nindent 12 }}
             {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /mq_health_check
+              port: 9050
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `livenessProbe` configuration to the Captain deployment to perform health checks on the `/api/healthz` endpoint.
- Added `livenessProbe` configuration to the Controller deployment to perform health checks on the `/mq_health_check` endpoint.
- Configured initial delay, period, timeout, and failure threshold for both liveness probes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>captain-deployment.yml</strong><dd><code>Add liveness probe to Captain deployment for health checks</code></dd></summary>
<hr>

charts/agh3/templates/captain/captain-deployment.yml
<li>Added <code>livenessProbe</code> configuration for the Captain deployment.<br> <li> Configured HTTP GET request to <code>/api/healthz</code> on port <code>8080</code>.<br> <li> Set initial delay, period, timeout, and failure threshold for the <br>liveness probe.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Leukocyte-Lab/helm-charts/pull/170/files#diff-6dfdd2c92837e5a09203b6356aba65cae3ce052cb8ef822d9fa5047133ce3596">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>controller-deployment.yml</strong><dd><code>Add liveness probe to Controller deployment for health checks</code></dd></summary>
<hr>

charts/agh3/templates/controller/controller-deployment.yml
<li>Added <code>livenessProbe</code> configuration for the Controller deployment.<br> <li> Configured HTTP GET request to <code>/mq_health_check</code> on port <code>9050</code>.<br> <li> Set initial delay, period, timeout, and failure threshold for the <br>liveness probe.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Leukocyte-Lab/helm-charts/pull/170/files#diff-654aa3e8dafe7c0599dec8fd74fefa347b8a7dae0e8f1bd1be18ca6354d45c98">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

