### PR TITLE
ci: Create workflow to auto update release channel after PR merged.

### DIFF
--- a/.github/workflows/agh3-update-develop-release-channel.yml
+++ b/.github/workflows/agh3-update-develop-release-channel.yml
@@ -1,0 +1,36 @@
+name: ⚙️ [AGH3] Auto Update Develop Release Channel
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - build/release-chart-agh3-**
+
+jobs:
+  trigger-develop-release-channel-update:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: 🔔 Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: 👁️ Lookup Chart Version
+        id: chartVersion
+        uses: mikefarah/yq@v4
+        with:
+          cmd: yq '.version' charts/agh3/Chart.yaml
+      - name: 👁️ Lookup App Version
+        id: appVersion
+        uses: mikefarah/yq@v4
+        with:
+          cmd: yq '.appVersion' charts/agh3/Chart.yaml
+
+      - name: 📢 Invoke workflow to update Release Channel
+        run: |
+          echo '{"chart_version": "${{ steps.chartVersion.outputs.result }}", "app_veresion": "${{ steps.appVersion.outputs.result }}"}' | \
+            gh workflow run agh3-ctr-update-release.yaml -R Leukocyte-Lab/ArgusHack3 -r develop --json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Introduced a new GitHub Actions workflow to automate the update of the develop release channel upon PR merge.
- The workflow triggers on closed pull requests targeting branches matching `build/release-chart-agh3-**`.
- It includes steps to check out the repository, retrieve chart and app versions using `yq`, and invoke another workflow to update the release channel.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agh3-update-develop-release-channel.yml</strong><dd><code>Add workflow for auto-updating develop release channel on PR merge</code></dd></summary>
<hr>

.github/workflows/agh3-update-develop-release-channel.yml
<li>Added a new GitHub Actions workflow to auto-update the develop release <br>channel.<br> <li> Triggered on PR merge events for specific branches.<br> <li> Includes steps to check out the repository, lookup chart and app <br>versions, and invoke another workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Leukocyte-Lab/helm-charts/pull/186/files#diff-417194e8ef9f9bcd8b698d47919b4ccad4d1b0450da85ba3de8692265f631f7a">+36/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

