### PR TITLE
fix: OIDC secretRefs should be optional.

### DIFF
--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -122,21 +122,25 @@ spec:
                 secretKeyRef:
                   key: url
                   name: {{ .Values.captain.secret.oidc.secretName }}
+                  optional: true
             - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   key: client-id
                   name: {{ .Values.captain.secret.oidc.secretName }}
+                  optional: true
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   key: client-secret
                   name: {{ .Values.captain.secret.oidc.secretName }}
+                  optional: true
             - name: OIDC_REALM
               valueFrom:
                 secretKeyRef:
                   key: realm
                   name: {{ .Values.captain.secret.oidc.secretName }}
+                  optional: true
             {{- if .Values.captain.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.captain.extraEnv "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `optional: true` to the `secretKeyRef` entries for `url`, `client-id`, `client-secret`, and `realm` in the OIDC configuration.
- Ensured that the OIDC secret references are optional in the Captain deployment YAML file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>captain-deployment.yml</strong><dd><code>Make OIDC secret references optional in deployment configuration</code></dd></summary>
<hr>

charts/agh3/templates/captain/captain-deployment.yml
<li>Added <code>optional: true</code> to several <code>secretKeyRef</code> entries.<br> <li> Made OIDC secret references optional in the deployment configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Leukocyte-Lab/helm-charts/pull/196/files#diff-6dfdd2c92837e5a09203b6356aba65cae3ce052cb8ef822d9fa5047133ce3596">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

