### PR TITLE
Release agh3 tar ball to GitHub Pages

### DIFF
--- a/.github/workflows/agh3-auto-release.yaml
+++ b/.github/workflows/agh3-auto-release.yaml
@@ -14,6 +14,14 @@ jobs:
       - name: 🔔 Checkout
         uses: actions/checkout@v4
         with:
+          path: src
+          fetch-depth: 0
+
+      - name: 🔔 Checkout
+        uses: actions/checkout@v4
+        with:
+          path: dest
+          ref: 'gh-pages'
           fetch-depth: 0
 
       - name: ⚙️ Configure Git
@@ -26,13 +34,18 @@ jobs:
         with:
           version: v3.13.3
 
-      - name: 📦 Add Helm dependency repos
+      - name: Package Helm Charts
+        shell: bash
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add lkclab https://charts.lkc-lab.com
-          helm repo update
-
+          helm dep up src/charts/agh3
+          helm package src/charts/agh3 -u -d dest
+      
       - name: 🎁 Release Chart
-        uses: helm/chart-releaser-action@v1
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        shell: bash
+        working-directory: dest
+        run: |
+          helm repo index . --url https://charts.lkc-lab.com/ --merge index.yaml 
+          git add $(git ls-files -o --exclude-standard)
+          git add index.yaml
+          git commit -m "Release from ref: $GITHUB_SHA"
+          git push          


### PR DESCRIPTION
This commits updates the current agh3 auto release workflow to publish the tar ball to GitHub Pages so that user can directly download the release using charts.lkc-lab.com domain.