### PR TITLE
fix: Lock postgresql image tag to 15.7.0 due to issues.

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -214,7 +214,7 @@ postgresql:
   ##
   image:
     repository: docker/bitnami/postgresql
-    tag: 15
+    tag: 15.7.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param postgresql.auth.enabled Enable postgresql auth secret generate


### PR DESCRIPTION
ref: bitnami/containers#74788

## Summary by Sourcery

Bug Fixes:
- Lock the PostgreSQL image tag to version 15.7.0 to address issues with the previous tag.