### PR TITLE
build: Release chart/agh3 `v3.9.1`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.9.0
+version: 3.9.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -655,7 +655,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.8.1
+    tag: v1.9.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.9.1`
- App Version: `3.7.0`
  - Captain: `v1.9.0`
  - Controller: `v0.7.2`
  - UI: `v1.9.1`
  - Report: `v1.1.4`

## Summary by Sourcery

Release chart/agh3 version 3.9.1 with updated UI image tag to v1.9.1.

Build:
- Update chart version to 3.9.1 in Chart.yaml.

Deployment:
- Update UI image tag to v1.9.1 in values.yaml.