### PR TITLE
feat: add captain crd cluster role

### DIFF
--- a/charts/agh3/templates/captain/captain-clusterrole.yml
+++ b/charts/agh3/templates/captain/captain-clusterrole.yml
@@ -7,6 +7,24 @@ metadata:
     {{- include "AGH3.labels" . | nindent 4 }}
 rules:
 - apiGroups:
+  - agh.lkc-lab.com
+  resources:
+  - actions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agh.lkc-lab.com
+  resources:
+  - actions/status
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - pods


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a new cluster role for the Captain component with permissions to manage 'actions' resources in the 'agh.lkc-lab.com' API group.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208785227135591