### PR TITLE
build: Release chart/agh3 `v3.9.3`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.9.2
+version: 3.9.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.7.1"
+appVersion: "v3.7.2"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.9.3
+    tag: v1.9.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -655,7 +655,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.9.8
+    tag: v1.9.9
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.9.3`
- App Version: `3.7.2`
  - Captain: `v1.9.3`
  - Controller: `v0.7.2`
  - UI: `v1.9.9`
  - Report: `v1.1.4`

## Summary by Sourcery

Build:
- Update chart version to 3.9.3 and app version to 3.7.2 in Chart.yaml.