### PR TITLE
[BREAKING CHANGE] feat: add default action result queue

### DIFF
--- a/charts/agh3/templates/base/rabbitmq-secret.yml
+++ b/charts/agh3/templates/base/rabbitmq-secret.yml
@@ -17,6 +17,39 @@ stringData:
 ) }}
   username: {{ .Values.rabbitmq.connection.user }}
   password: {{ print $password | quote }}
+  load_definition.json: |
+    {
+      "users": [
+        {
+          "name": "{{ .Values.rabbitmq.connection.user }}",
+          "password": {{ print $password | quote }},
+          "tags": "administrator"
+        }
+      ],
+      "queues":[
+        {
+          "name": "{{ .Values.rabbitmq.queueName }}",
+          "vhost":"/",
+          "durable":true,
+          "auto_delete":false,
+          "arguments":{}
+        }
+      ],
+      "vhosts": [
+        {
+          "name": "/"
+        }
+      ],
+      "permissions": [
+        {
+          "user": "{{ .Values.rabbitmq.connection.user }}",
+          "vhost": "/",
+          "configure": ".*",
+          "write": ".*",
+          "read": ".*"
+        }
+      ]
+    }
   uri: {{ include "rabbitmq-connection-string"
     (
       dict

--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -141,6 +141,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.captain.secret.minio.secretName }}
                   key: capt-minio-password
+            - name: RABBITMQ_QUEUE
+              value: {{ .Values.rabbitmq.queueName }}
             - name: RABBITMQ_Conn
               valueFrom:
                 secretKeyRef:

--- a/charts/agh3/templates/controller/controller-deployment.yml
+++ b/charts/agh3/templates/controller/controller-deployment.yml
@@ -65,6 +65,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.controller.secret.minio.secretName }}
                   key: executor-minio-password
+            - name: RABBITMQ_QUEUE
+              value: {{ .Values.rabbitmq.queueName }}
             - name: RABBITMQ_Conn
               valueFrom:
                 secretKeyRef:

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -388,6 +388,11 @@ redis:
 ## @section RabbitMQ parameters
 ##
 rabbitmq:
+  ## @param rabbitmq.queueName Name of the RabbitMQ queue
+  queueName: action_crd_result
+  loadDefinition:
+    enabled: true
+    existingSecret: agh-rabbitmq-secret
   connection:
     ## @param rabbitmq.connection.type Choose to use external RabbitMQ or internal RabbitMQ
     ## internal` or `external` in string


### PR DESCRIPTION
This PR creates rabbitmq default action result queue on boot

## Summary by Sourcery

Introduce a default RabbitMQ action result queue created on boot and configure its parameters in the values.yaml file.

New Features:
- Introduce a default RabbitMQ action result queue that is created on boot.

Enhancements:
- Add configuration for RabbitMQ queue name and load definition in the values.yaml file.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208966377580143