### PR TITLE
feat: Add CHART_NAME environment variable to captain deployment

### DIFF
--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -174,6 +174,8 @@ spec:
                   key: realm
                   name: {{ .Values.captain.secret.oidc.secretName }}
                   optional: true
+            - name: CHART_NAME
+              value: {{ .Chart.Name | quote }}
             {{- if .Values.global.proxy.enabled}}
             {{- include "global.proxy.envs" . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Set the CHART_NAME environment variable in the captain deployment to the name of the chart.