### PR TITLE
build: Release chart/agh3 `v3.10.2`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.1
+version: 3.10.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.8.1"
+appVersion: "v3.8.2"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.10.1
+    tag: v1.10.2
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain


### PR DESCRIPTION
- Chart Version: `3.10.2`
- App Version: `3.8.2`
  - Captain: `v1.10.2`
  - Controller: `v0.7.2`
  - UI: `v1.10.0`
  - Report: `v1.1.4`

## Summary by Sourcery

Build:
- Release chart/agh3 `v3.10.2` which updates the app version to `3.8.2` including Captain `v1.10.2`, Controller `v0.7.2`, UI `v1.10.0`, and Report `v1.1.4`.