### PR TITLE
Fix DKIM Signing Issue for Postfix

### DIFF
--- a/charts/postfix/templates/cm.yaml
+++ b/charts/postfix/templates/cm.yaml
@@ -99,8 +99,8 @@ data:
 
 
     smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
-    myhostname = smtp.bas-mail-test.com
-    mydomain = bas-mail-test.com
+    myhostname = {{ .Values.mail_myhostname }}
+    mydomain = {{ .Values.mydomain }}
     lmtp_host_lookup = native
     smtp_host_lookup = native
     alias_maps = hash:/etc/aliases

--- a/charts/postfix/templates/cm.yaml
+++ b/charts/postfix/templates/cm.yaml
@@ -57,3 +57,67 @@ data:
     # by the package dns-root-data.
     #TrustAnchorFile		/usr/share/dns/root.key
     #Nameservers		127.0.0.1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postfix-config
+  labels:
+    {{- include "postfix.labels" . | nindent 4 }}
+data:
+  main.cf: |
+    # See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+    # Debian specific:  Specifying a file name will cause the first
+    # line of that file to be used as the name.  The Debian default
+    # is /etc/mailname.
+    #myorigin = /etc/mailname
+
+    smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+    biff = no
+
+    # appending .domain is the MUA's job.
+    append_dot_mydomain = no
+
+    # Uncomment the next line to generate "delayed mail" warnings
+    #delay_warning_time = 4h
+
+    readme_directory = no
+
+    # See http://www.postfix.org/COMPATIBILITY_README.html -- default to 3.6 on
+    # fresh installs.
+    compatibility_level = 3.6
+
+    # TLS parameters
+    smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+    smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    smtpd_tls_security_level=may
+
+    smtp_tls_CApath=/etc/ssl/certs
+    smtp_tls_security_level=may
+    smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+
+    smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+    myhostname = smtp.bas-mail-test.com
+    mydomain = bas-mail-test.com
+    lmtp_host_lookup = native
+    smtp_host_lookup = native
+    alias_maps = hash:/etc/aliases
+    alias_database = hash:/etc/aliases
+    #mydestination = $myhostname, /etc/mailname, localhost, localhost.localdomain, localhost
+    relayhost =
+    mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 0.0.0.0/0
+    mailbox_size_limit = 0
+    recipient_delimiter = +
+    inet_interfaces = all
+    #inet_protocols = all
+    inet_protocols = ipv4
+
+    maillog_file = /dev/stdout
+
+    # Milter configuration
+    milter_default_action = accept
+    milter_protocol = 6
+    smtpd_milters = inet:127.0.0.1:8891
+    non_smtpd_milters = inet:127.0.0.1:8891

--- a/charts/postfix/templates/deployment.yaml
+++ b/charts/postfix/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
               value: {{ .Values.mydomain }}
             - name: mail_myhostname
               value: {{ .Values.mail_myhostname }}
+          volumeMounts:
+            - name: postfix-config
+              mountPath: /etc/postfix/main.cf
+              subPath: main.cf
         - name: dkim
           image: {{ include "dkim.image" . }}
           imagePullPolicy: {{ .Values.dkim.image.pullPolicy }}
@@ -71,3 +75,6 @@ spec:
         - name: domainkey
           secret:
             secretName: rsa-private-key
+        - name: postfix-config
+          configMap:
+            name: postfix-config

--- a/charts/postfix/templates/deployment.yaml
+++ b/charts/postfix/templates/deployment.yaml
@@ -29,11 +29,6 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          env:
-            - name: mydomain
-              value: {{ .Values.mydomain }}
-            - name: mail_myhostname
-              value: {{ .Values.mail_myhostname }}
           volumeMounts:
             - name: postfix-config
               mountPath: /etc/postfix/main.cf


### PR DESCRIPTION
This commit updates postfix config to use opendkim correctly.

## Summary by Sourcery

Build:
- Update Postfix configuration to integrate with OpenDKIM.