### PR TITLE
build: Release chart/agh3 `v3.10.3`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.2
+version: 3.10.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.8.2"
+appVersion: "v3.8.3"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.10.3
+    tag: v1.10.6
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -603,7 +603,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v0.7.2
+    tag: v1.0.0-alpha
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller
@@ -655,7 +655,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.10.3
+    tag: v1.10.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -603,7 +603,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v1.0.0-alpha
+    tag: v0.7.2
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller


### PR DESCRIPTION
- Chart Version: `3.10.3`
- App Version: `3.8.3`
  - Captain: `v1.10.6`
  - Controller: `v1.0.0-alpha`
  - UI: `v1.10.5`
  - Report: `v1.1.4`

## Summary by Sourcery

Build:
- Release chart/agh3 `v3.10.3` which updates the app to version `3.8.3`.