### PR TITLE
build: bump posfix version to 0.1.2

### DIFF
--- a/charts/agh3/Chart.lock
+++ b/charts/agh3/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.19.1
 - name: postfix
   repository: https://charts.lkc-lab.com
-  version: 0.1.1
-digest: sha256:fb6ba056468f47e486b96134dccb3de190f3525da983e7413f352b5bd6051982
-generated: "2024-09-11T12:52:01.457922+08:00"
+  version: 0.1.2
+digest: sha256:57c4fcdeb424562a7f162a86b9b4e70ce4057b1903a10b832be7f5a95b346157
+generated: "2025-02-03T17:12:10.669177+08:00"

--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.8
+version: 3.10.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -40,6 +40,6 @@ dependencies:
     version: 2.19.1
     repository: https://charts.bitnami.com/bitnami
   - name: postfix
-    version: 0.1.1
+    version: 0.1.2
     repository: https://charts.lkc-lab.com
     condition: postfix.enabled


### PR DESCRIPTION
## Summary by Sourcery

Bump the chart version to 3.10.9 and the Postfix dependency version to 0.1.2.

Build:
- Bump Postfix chart dependency to 0.1.2.
- Increment the chart version to 3.10.9.