### PR TITLE
build: Release chart/agh3-playground `v1.4.0`

### DIFF
--- a/charts/playground/Chart.yaml
+++ b/charts/playground/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.3.2"
+appVersion: "v1.4.0"
 dependencies:
   - name: common
     version: 2.19.1

--- a/charts/playground/values.yaml
+++ b/charts/playground/values.yaml
@@ -74,7 +74,7 @@ playground:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-playground
-    tag: v1.3.2
+    tag: v1.4.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param playground.secret.enabled Enable secret generate for Playground
@@ -115,14 +115,13 @@ playground:
       enabled: true
       ## @skip playground.secret.ai.workflows List of AI workflows
       ##
-      workflows:
-        []
-        # @example
-        #
-        # - name: "generate-mitigations"
-        #   token: "token1"
-        # - name: "generate-mitigation"
-        #   token: "token2"
+      workflows: []
+      # @example
+      #
+      # - name: "generate-mitigations"
+      #   token: "token1"
+      # - name: "generate-mitigation"
+      #   token: "token2"
   ## @section Playground service provisioning parameters
   ##
   ## @param playground.service.backendRef.kind Backend Service kind (available options: Service, ExternalService)


### PR DESCRIPTION
- Chart Version: `1.4.0`
- App Version: `1.4.0`
  - Playground: `v1.4.0`

## Summary by Sourcery

Build:
- Bump chart and app version to 1.4.0.