### PR TITLE
feat/add ai api endpoint env for playground

### DIFF
--- a/.github/workflows/agh3-playground-test.yml
+++ b/.github/workflows/agh3-playground-test.yml
@@ -50,7 +50,8 @@ jobs:
             --set playground.secret.firebase.messagingSenderId='ci-test-firebase-sender-id' \
             --set playground.secret.firebase.appId='1:ci-test-firebase-sender-id:web:ci-test-firebase-app-id' \
             --set playground.secret.firebase.measurementId='G-CI_TEST_CODE' \
-            --set-json playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}] \
+            --set playground.service.ai.endpoint='http://ai-service.example.com:8080' \
+            --set-json 'playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}]' \
             -n agh3-playground
 
       - name: 🧪 Run chart-testing -> internal mode with custom namespace
@@ -68,7 +69,8 @@ jobs:
             --set playground.secret.firebase.messagingSenderId='ci-test-firebase-sender-id' \
             --set playground.secret.firebase.appId='1:ci-test-firebase-sender-id:web:ci-test-firebase-app-id' \
             --set playground.secret.firebase.measurementId='G-CI_TEST_CODE' \
-            --set-json playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}] \
+            --set playground.service.ai.endpoint='http://ai-service.example.com:8080' \
+            --set-json 'playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}]' \
             -n agh3-playground
 
       - name: 🧪 Run chart-testing -> external mode
@@ -86,5 +88,6 @@ jobs:
             --set playground.secret.firebase.messagingSenderId='ci-test-firebase-sender-id' \
             --set playground.secret.firebase.appId='1:ci-test-firebase-sender-id:web:ci-test-firebase-app-id' \
             --set playground.secret.firebase.measurementId='G-CI_TEST_CODE' \
-            --set-json playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}] \
+            --set playground.service.ai.endpoint='http://ai-service.example.com:8080' \
+            --set-json 'playground.secret.ai.workflows=[{"name":"generate-mitigations","token":"test-token-123"},{"name":"generate-mitigation","token":"test-token-456"}]' \
             -n agh3-playground

--- a/charts/playground/templates/playground-deployment.yml
+++ b/charts/playground/templates/playground-deployment.yml
@@ -26,6 +26,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: API_ENDPOINT
               value: {{ include "playground.apiEndpoint" . }}
+            - name: AI_API_ENDPOINT
+              value: {{ required "playground.service.ai.endpoint is required" .Values.playground.service.ai.endpoint | quote }}
             {{- if .Values.playground.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.playground.extraEnv "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/playground/values.yaml
+++ b/charts/playground/values.yaml
@@ -130,6 +130,7 @@ playground:
   ## @param playground.service.backendRef.port Backend Service port
   ## @param playground.service.backendRef.protocol Backend Service protocol
   ## @param playground.service.backendRef.endpoint Backend Service endpoint for the Playground service (required and must be full URL when playground.service.backendRef.kind is ExternalService, only the path or leave empty when playground.service.backendRef.kind is Service)
+  ## @param playground.service.ai.endpoint AI service endpoint
   ##
   service:
     backendRef:
@@ -138,6 +139,8 @@ playground:
       name: "captain"
       port: 8080
       protocol: "HTTP"
+      endpoint: ""
+    ai:
       endpoint: ""
   ## @param playground.extraEnv UI additional environment variables
   ##


### PR DESCRIPTION
- **feat: Add AI API endpoint env for playground template.**
- **ci: Update playground test case.**

## Summary by Sourcery

Add configurable endpoint for the AI service used in the playground.

Enhancements:
- Add `playground.service.ai.endpoint` to the Helm chart values.

CI:
- Update playground test cases to use the new AI service endpoint configuration.

Deployment:
- Add `AI_API_ENDPOINT` environment variable to the playground deployment, sourced from the `playground.service.ai.endpoint` Helm value.