### PR TITLE
build: Release chart/agh3-playground `v1.4.1`

### DIFF
--- a/charts/playground/Chart.yaml
+++ b/charts/playground/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.4.0"
+appVersion: "v1.4.1"
 dependencies:
   - name: common
     version: 2.19.1

--- a/charts/playground/values.yaml
+++ b/charts/playground/values.yaml
@@ -74,7 +74,7 @@ playground:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-playground
-    tag: v1.4.0
+    tag: v1.4.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param playground.secret.enabled Enable secret generate for Playground


### PR DESCRIPTION
- Chart Version: `1.4.1`
- App Version: `1.4.1`
  - Playground: `v1.4.1`

## Summary by Sourcery

Build:
- Bump chart and app versions to v1.4.1.