### PR TITLE
chore: disable kueue by default

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -346,7 +346,7 @@ minio:
 ## @section Kueue parameters
 kueue:
   ## @param kueue.enabled Enable internal kueue
-  enabled: true
+  enabled: false
   ## @skip kueue.fullnameOverride
   fullnameOverride: kueue
   queueName:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Disable Kueue by default in the agh3 chart's values.yaml file