### PR TITLE
Fix OpenDKIM Config

### DIFF
--- a/charts/postfix/templates/cm.yaml
+++ b/charts/postfix/templates/cm.yaml
@@ -51,7 +51,7 @@ data:
 
     # Hosts for which to sign rather than verify, default is 127.0.0.1. See the
     # OPERATION section of opendkim(8) for more information.
-    #InternalHosts		192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
+    InternalHosts		192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
 
     # The trust anchor enables DNSSEC. In Debian, the trust anchor file is provided
     # by the package dns-root-data.


### PR DESCRIPTION
This commit fixes OpenDKIM config to allow internal IP as internal host. This will allow dkim signing for mail coming from within the Kubernetes cluster via smtp instead of only for mail comming from the same pod.

## Summary by Sourcery

Bug Fixes:
- Allow internal IP addresses as internal hosts for DKIM signing, enabling signing for mail from within the Kubernetes cluster via SMTP.