### PR TITLE
build: Release chart/agh3 `v3.10.12`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.11
+version: 3.10.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.9.1"
+appVersion: "v3.9.2"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -562,7 +562,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.12.0
+    tag: v1.11.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -562,7 +562,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.11.0
+    tag: v1.12.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain


### PR DESCRIPTION
- Chart Version: `3.10.12`
- App Version: `3.9.2`
  - Captain: `v1.12.0`
  - Controller: `v0.7.2`
  - UI: `v1.11.0`
  - Report: `v1.1.4`

## Summary by Sourcery

Bump chart version to `3.10.12` and app version to `3.9.2`. Also, update Captain image tag to `v1.12.0`.

Build:
- Bump chart version to `3.10.12` and app version to `3.9.2`.
- Update Captain image tag to `v1.12.0`.