### PR TITLE
fix: adjust cpu limit to 100m for action loop

### DIFF
--- a/charts/agh3/templates/actionloop/actionloop-deployment.yml
+++ b/charts/agh3/templates/actionloop/actionloop-deployment.yml
@@ -123,7 +123,7 @@ spec:
           resources:
             requests:
               memory: "128Mi"
-              cpu: "500m"
+              cpu: "100m"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reduced the CPU limit for the action loop container to prevent excessive resource consumption.