### PR TITLE
build: Release chart/agh3 `v3.10.14`

### DIFF
--- a/charts/agh3/Chart.lock
+++ b/charts/agh3/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.19.1
 - name: postfix
   repository: https://charts.lkc-lab.com
-  version: 0.1.2
-digest: sha256:57c4fcdeb424562a7f162a86b9b4e70ce4057b1903a10b832be7f5a95b346157
-generated: "2025-02-03T17:12:10.669177+08:00"
+  version: 0.1.3
+digest: sha256:b32ccd998feedd631bbdd9e63c44734ccaf4d98460d5e05e10102f5beb741517
+generated: "2025-02-20T09:47:13.980121+08:00"

--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.13
+version: 3.10.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -40,6 +40,6 @@ dependencies:
     version: 2.19.1
     repository: https://charts.bitnami.com/bitnami
   - name: postfix
-    version: 0.1.2
+    version: 0.1.3
     repository: https://charts.lkc-lab.com
     condition: postfix.enabled

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -562,7 +562,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.12.0
+    tag: v1.11.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -562,7 +562,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.11.0
+    tag: v1.12.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain


### PR DESCRIPTION
- Chart Version: `3.10.14`
- App Version: `3.9.2`
  - ActionLoop: `v1.12.0`
  - Captain: `v1.12.0`
  - Controller: `v0.7.2`
  - UI: `v1.11.1`
  - Report: `v1.1.4`

## Summary by Sourcery

Build:
- Bump chart version to `3.10.14` and Captain version to `v1.12.0`.