### PR TITLE
feat: add minio init container

### DIFF
--- a/charts/agh3/templates/_helpers.tpl
+++ b/charts/agh3/templates/_helpers.tpl
@@ -183,6 +183,13 @@ Return the proper rabbitmq-test-client image name
 {{- end }}
 
 {{/*
+  Return the proper minio-test-client image name
+*/}}
+{{- define "minio-test-client.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.minio.helpers.test.image "global" .Values.global) }}
+{{- end }}
+
+{{/*
 Return the proper kueue-initialize image name
 */}}
 {{- define "kueue-initialize.image" -}}

--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -36,6 +36,19 @@ spec:
               "until redis-cli -h redis-master.$(NAMESPACE).svc.cluster.local -a $REDIS_PASSWORD ping; do echo waiting for redis; sleep 1; done",
             ]
         {{- end }}
+        - name: captain-init-minio
+          image: {{ include "minio-test-client.image" . }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            [
+              "sh",
+              "-c",
+              "until curl http://minio.$(NAMESPACE).svc.cluster.local:9000; do echo $(date) waiting... && sleep 1; done;"
+            ]
         - name: captain-init-rabbitmq
           image: {{ include "rabbitmq-test-client.image" . }}
           env:

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -313,6 +313,19 @@ minio:
     tag: 2023.4.12
     pullPolicy: IfNotPresent
     pullSecrets: []
+  helpers:
+    ## Minio Connection Test image
+    ## @param minio.helpers.test.image.repository Minio Connection Test image repository
+    ## @param minio.helpers.test.image.tag Minio Connection Test image tag (immutable tags are recommended)
+    ## @param minio.helpers.test.image.pullPolicy Minio Connection Test image pull policy
+    ## @param minio.helpers.test.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    test:
+      image:
+        repository: docker/library/curlimages/curl
+        tag: latest
+        pullPolicy: IfNotPresent
+        pullSecrets: []
   ## @param minio.auth.rootUser Internal database root user
   ## @param minio.auth.rootPassword Internal database root password
   ##


### PR DESCRIPTION
## Summary by Sourcery

Adds an init container to the Captain deployment to test the MinIO connection before the Captain application starts. This ensures that Captain can connect to MinIO before attempting to use it.

New Features:
- Adds an init container to the Captain deployment to test the MinIO connection before the Captain application starts.

Tests:
- Adds a minio connection test image.