### PR TITLE
feat: add gcp parser sa secret

### DIFF
--- a/charts/agh3/templates/parser/parser-secret.yml
+++ b/charts/agh3/templates/parser/parser-secret.yml
@@ -1,0 +1,10 @@
+{{- if and .Values.parser.secret.enabled .Values.parser.secret.sa.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.parser.secret.sa.secretName}}
+  labels:
+    {{- include "AGH3.labels" . | nindent 4 }}
+stringData:
+  sa.json: {{ .Values.parser.secret.sa.json | quote}}
+{{- end }}

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -691,6 +691,17 @@ parser:
       secretName: parser-minio-secret
       user: "parser-minio-user"
       password: ""
+    ## @param parser.secret.sa.enabled Enable secret generate for Parser service account
+    ## @param parser.secret.sa.secretName Secret name for Parser service account
+    ## @param parser.secret.sa.json Parser service account JSON
+    ##
+    sa:
+      enabled: true
+      secretName: parser-sa-secret
+      json: |-
+        {
+          "type": "service_account",
+        }
 ## @section AGH3-Controller parameters
 ## @descriptionStart
 ## Controller module for AGH3.


### PR DESCRIPTION
## Summary by Sourcery

Add support for generating a Kubernetes secret for a GCP service account in the parser component of the Helm chart

New Features:
- Introduce configuration to enable creating a Kubernetes secret for a Parser service account with GCP credentials

Enhancements:
- Extend the Helm chart values to support service account secret configuration