### PR TITLE
fix: actionloop image registry url use global

### DIFF
--- a/charts/agh3/templates/actionloop/actionloop-deployment.yml
+++ b/charts/agh3/templates/actionloop/actionloop-deployment.yml
@@ -82,7 +82,7 @@ spec:
           image: {{ include "actionLoop.image" . }}
           env:
             - name: IMAGE_REGISTRY_URL
-              value: "registry.lkc-lab.com"
+              value: {{ .Values.global.imageRegistry }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes the actionloop image registry URL to use the global value.