### PR TITLE
build: Release chart/agh3 `v3.10.17`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.16
+version: 3.10.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.9.2"
+appVersion: "v3.9.3"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.11.0
+    tag: v1.11.2
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -655,7 +655,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.11.1
+    tag: v1.11.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.10.17`
- App Version: `3.9.3`
  - Captain: `v1.11.2`
  - Controller: `v0.7.2`
  - UI: `v1.11.4`
  - Report: `v1.1.4`

## Summary by Sourcery

Bump chart version to 3.10.17 and app version to v3.9.3, including updates to Captain and UI versions.

Build:
- Bump chart version to 3.10.17.
- Bump app version to v3.9.3.
- Update Captain version to v1.11.2.
- Update UI version to v1.11.4.