### PR TITLE
fix: update curl image repository in values.yaml

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -322,7 +322,7 @@ minio:
     ##
     test:
       image:
-        repository: docker/library/curlimages/curl
+        repository: docker/curlimages/curl
         tag: latest
         pullPolicy: IfNotPresent
         pullSecrets: []


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Corrected the curl image repository path from 'docker/library/curlimages/curl' to 'docker/curlimages/curl'