### PR TITLE
build: Release chart/agh3 `v3.11.5`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.11.4
+version: 3.11.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -565,7 +565,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.12.0
+    tag: v1.12.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -595,7 +595,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.12.0
+    tag: v1.12.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain


### PR DESCRIPTION
- Chart Version: `3.11.5`
- App Version: `3.10.3`
  - ActionLoop: `v1.12.1`
  - Captain: `v1.12.1`
  - Controller: `v1.0.0`
  - UI: `v1.11.4`
  - Report: `v1.1.4`

## Summary by Sourcery

Upgrade chart version and component versions for AGH3 chart

Build:
- Increment chart version from 3.11.4 to 3.11.5
- Update ActionLoop image tag from v1.12.0 to v1.12.1
- Update Captain image tag from v1.12.0 to v1.12.1