### PR TITLE
build: Release chart/agh3 `v3.10.18`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.10.17
+version: 3.10.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.11.2
+    tag: v1.12.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -603,7 +603,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v0.7.2
+    tag: v1.0.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -511,7 +511,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.12.1
+    tag: v1.11.3
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -603,7 +603,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v1.0.0
+    tag: v0.7.2
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller


### PR DESCRIPTION
- Chart Version: `3.10.18`
- App Version: `3.9.3`
  - Captain: `v1.12.1`
  - Controller: `v1.0.0`
  - UI: `v1.11.4`
  - Report: `v1.1.4`

## Summary by Sourcery

Update chart version and component images for AGH3 release

Enhancements:
- Update Captain image from v1.11.2 to v1.12.1
- Update Controller image from v0.7.2 to v1.0.0

Build:
- Bump chart version from 3.10.17 to 3.10.18