### PR TITLE
feat: add readyz for action loop

### DIFF
--- a/charts/agh3/templates/actionloop/actionloop-deployment.yml
+++ b/charts/agh3/templates/actionloop/actionloop-deployment.yml
@@ -120,6 +120,14 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 10
             failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 10
+            failureThreshold: 3
           resources:
             requests:
               memory: "128Mi"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a readiness probe endpoint at /readyz on port 8080 for the action loop deployment