### PR TITLE
feat: add embedding minio bucket and update parser policy to include

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -342,6 +342,8 @@ minio:
     buckets:
       - name: intelli-bridge
         versioning: true
+      - name: embedding
+        versioning: true
     ## @skip minio.provisioning.policies
     ## @skip minio.provisioning.usersExistingSecrets
     ##
@@ -361,6 +363,8 @@ minio:
             resources:
               - "arn:aws:s3:::intelli-bridge/*"
               - "arn:aws:s3:::intelli-bridge"
+              - "arn:aws:s3:::embedding/*"
+              - "arn:aws:s3:::embedding"
             actions:
               - "s3:GetBucketLocation"
               - "s3:PutObject"


### PR DESCRIPTION
## Summary by Sourcery

Add a new embedding MinIO bucket and update the parser policy to include access permissions for the new bucket

New Features:
- Create a new MinIO bucket named 'embedding' with versioning enabled

Enhancements:
- Extend the MinIO policy to grant access permissions for the new embedding bucket