### PR TITLE
build: Release chart/agh3 `v3.11.7`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.11.6
+version: 3.11.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.10.3"
+appVersion: "v3.10.4"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -569,7 +569,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.12.1
+    tag: v1.13.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -599,7 +599,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.12.1
+    tag: v1.13.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -775,7 +775,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.11.4
+    tag: v1.11.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.11.7`
- App Version: `3.10.4`
  - ActionLoop: `v1.13.0`
  - Captain: `v1.13.0`
  - Controller: `v1.0.0`
  - UI: `v1.11.5`
  - Report: `v1.1.4`

## Summary by Sourcery

Release Helm chart agh3 v3.11.7 and update application version and container images

Chores:
- Bump chart version to v3.11.7
- Update appVersion to v3.10.4
- Upgrade actionLoop and captain images to v1.13.0
- Upgrade UI image to v1.11.5