### PR TITLE
Feat/agh 630/packet bucket

### DIFF
--- a/charts/agh3/crds/actions.crds.yaml
+++ b/charts/agh3/crds/actions.crds.yaml
@@ -440,7 +440,7 @@ spec:
                 - activeStatus
               type: object
           type: object
-      served: true
+      served: false
       storage: false
       subresources:
         status: {}
@@ -801,6 +801,439 @@ spec:
                     identify the action is a root action
                     kubebuilder:default:false
                   type: boolean
+              required:
+                - containers
+                - historyID
+              type: object
+            status:
+              description: ActionStatus defines the observed state of Action
+              properties:
+                activeStatus:
+                  default: Pending
+                  description: ActiveStatus is depended on worker's status
+                  type: string
+                worker:
+                  description: Pointers to currently running worker.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+              required:
+                - activeStatus
+              type: object
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.activeStatus
+          name: status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v3alpha1
+      schema:
+        openAPIV3Schema:
+          description: Action is the Schema for the actions API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ActionSpec defines the desired state of Action
+              properties:
+                containers:
+                  description:
+                    setup the containers of worker that will be created when
+                    executing a Action.
+                  items:
+                    properties:
+                      Envs:
+                        items:
+                          description:
+                            EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description:
+                                Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description:
+                                Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description:
+                                        Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description:
+                                        Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description:
+                                        "Container name: required for volumes,
+                                        optional for env vars"
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description:
+                                        Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: "Required: resource to select"
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description:
+                                    Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      args:
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        items:
+                          type: string
+                        type: array
+                      image:
+                        type: string
+                      volumeMounts:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      workingDir:
+                        type: string
+                    required:
+                      - image
+                    type: object
+                  type: array
+                historyID:
+                  description: identify the action is from same history
+                  type: string
+                hostAliases:
+                  description: respect Pod's HostAlias
+                  items:
+                    description: |-
+                      HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                      pod's hosts file.
+                    properties:
+                      hostnames:
+                        description: Hostnames for the above IP address.
+                        items:
+                          type: string
+                        type: array
+                      ip:
+                        description: IP address of the host file entry.
+                        type: string
+                    type: object
+                  type: array
+                initContainers:
+                  description:
+                    setup the initContainers of worker that will be created
+                    when executing a Action.
+                  items:
+                    properties:
+                      Envs:
+                        items:
+                          description:
+                            EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description:
+                                Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description:
+                                Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description:
+                                        Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description:
+                                        Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description:
+                                        "Container name: required for volumes,
+                                        optional for env vars"
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description:
+                                        Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: "Required: resource to select"
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description:
+                                    Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description:
+                                        The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description:
+                                        Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      args:
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        items:
+                          type: string
+                        type: array
+                      image:
+                        type: string
+                      volumeMounts:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      workingDir:
+                        type: string
+                    required:
+                      - image
+                    type: object
+                  type: array
+                isRoot:
+                  description: |-
+                    identify the action is a root action
+                    kubebuilder:default:false
+                  type: boolean
+                packet:
+                  description: |-
+                    packet determines whether we need to extend with packet capture feature
+                    kubebuilder:default={"enabled": false, "location": ""}
+                  properties:
+                    enabled:
+                      type: boolean
+                    location:
+                      type: string
+                  required:
+                    - enabled
+                    - location
+                  type: object
               required:
                 - containers
                 - historyID

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -344,6 +344,7 @@ minio:
         versioning: true
       - name: embedding
         versioning: true
+      - name: packet
     ## @skip minio.provisioning.policies
     ## @skip minio.provisioning.usersExistingSecrets
     ##


### PR DESCRIPTION
## Summary by Sourcery

Extend the Action CustomResource to support packet capture, bump the CRD to v3alpha1 with enhanced schema and deprecate older versions, and update chart values to provision a packet bucket

New Features:
- Add packet capture support in the Action CRD via new `packet.enabled` and `packet.location` fields

Enhancements:
- Introduce a new v3alpha1 version of the Action CRD with updated schema, additional printer columns, and status subresources
- Disable older served versions of the Action CRD by setting `served: false` and `storage: false`

Chores:
- Include a `packet` bucket entry in the MinIO provisioning configuration