### PR TITLE
feat: add new default bucket packet for storing packet capture traffi…

### DIFF
--- a/charts/agh3/templates/actionloop/actionloop-deployment.yml
+++ b/charts/agh3/templates/actionloop/actionloop-deployment.yml
@@ -114,6 +114,21 @@ spec:
               value: {{ .Chart.AppVersion | quote }}
             - name: KEYGEN_URL
               value: {{ .Values.keygen.url | default "https://api.keygen.sh"}}
+            - name: MINIO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.minio.secret.secretName }}
+                  key: url
+            - name: MINIO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.captain.secret.minio.secretName }}
+                  key: capt-minio-user
+            - name: MINIO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.captain.secret.minio.secretName }}
+                  key: capt-minio-password
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/agh3/templates/minio/agh-minio-users-secret.yml
+++ b/charts/agh3/templates/minio/agh-minio-users-secret.yml
@@ -69,4 +69,26 @@ stringData:
     policies={{ .name }}
     {{- end }}
     setPolicies=false
+  {{ .Values.packet.secret.minio.user }}: |
+    username={{ .Values.packet.secret.minio.user }}
+    password={{
+      (
+        default
+          .Values.packet.secret.minio.password
+          (
+            include "specify-password"
+              (
+                dict
+                  "domain" (default .Values.ingress.host "app.argushack.com")
+                  "token" .Values.keygen.apiToken
+                  "prefix" .Values.packet.secret.minio.secretName
+              )
+          )
+      ) | substr 0 40
+    }}
+    disabled=false
+    {{- with index .Values.minio.provisioning.policies 2 }}
+    policies={{ .name }}
+    {{- end }}
+    setPolicies=false
 {{- end }}

--- a/charts/agh3/templates/packet/packet-minio-secret.yml
+++ b/charts/agh3/templates/packet/packet-minio-secret.yml
@@ -1,0 +1,25 @@
+{{- if and .Values.controller.enabled (and .Values.packet.secret.enabled .Values.packet.secret.minio.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.packet.secret.minio.secretName }}
+  labels:
+    {{- include "AGH3.labels" . | nindent 4 }}
+stringData:
+  packet-minio-user: {{ (required "packet.secret.minio.user is required" .Values.packet.secret.minio.user) | quote }}
+  packet-minio-password: {{
+    (
+      default
+        .Values.packet.secret.minio.password
+        (
+          include "specify-password"
+            (
+              dict
+                "domain" (default .Values.ingress.host "app.argushack.com")
+                "token" .Values.keygen.apiToken
+                "prefix" .Values.packet.secret.minio.secretName
+            )
+        )
+    ) | substr 0 40 | quote
+  }}
+{{- end }}

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -372,6 +372,18 @@ minio:
               - "s3:GetObject"
               - "s3:ListBucket"
               - "s3:HeadBucket"
+      - name: agh-packet-policy
+        statements:
+          - effect: "Allow"
+            resources:
+              - "arn:aws:s3:::packet/*"
+              - "arn:aws:s3:::packet"
+            actions:
+              - "s3:GetBucketLocation"
+              - "s3:PutObject"
+              - "s3:GetObject"
+              - "s3:ListBucket"
+              - "s3:HeadBucket"
     usersExistingSecrets:
       - agh-minio-users-secret
   ## @param minio.extraEnvVarsCM
@@ -675,6 +687,27 @@ captain:
   ## @param captain.extraEnv Captain additional environment variables
   ##
   extraEnv: {}
+## @section packet parameters
+## @descriptionStart
+## Packet module for AGH3.
+## descriptionEnd
+packet:
+  ## @param packet.secret.enabled Enable secrete generate for packet
+  ##
+  secret:
+    ## @param packet.secret.enabled Enable secret generate for packet
+    ##
+    enabled: true
+    ## @param packet.secret.minio.enabled Enable secret generate for Minio
+    ## @param packet.secret.minio.secretName Secret name for Minio
+    ## @param packet.secret.minio.user Minio user
+    ## @param packet.secret.minio.password Minio password
+    ##
+    minio:
+      enabled: true
+      secretName: packet-minio-secret
+      user: "packet-minio-user"
+      password: ""
 ## @section ai-parser parameters
 ## @descriptionStart
 ## AI Parser module for AGH3.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -344,6 +344,7 @@ minio:
         versioning: true
       - name: embedding
         versioning: true
+      - name: packet
     ## @skip minio.provisioning.policies
     ## @skip minio.provisioning.usersExistingSecrets
     ##


### PR DESCRIPTION
…c data

## Summary by Sourcery

Add support for a new packet capture storage bucket in MinIO, including automated credential management and deployment integration

New Features:
- Introduce `packet` Helm values and templates for automated generation and management of MinIO credentials
- Provision a new versioned `packet` bucket with an `agh-packet-policy` granting S3 access
- Expose MinIO URL, username, and password to the Actionloop deployment via environment variables