### PR TITLE
fix: add minio bucket check init container for captain deployment

### DIFF
--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -49,6 +49,29 @@ spec:
               "-c",
               "until curl http://minio.$(NAMESPACE).svc.cluster.local:9000; do echo $(date) waiting... && sleep 1; done;"
             ]
+        - name: captain-init-minio-bucket-intelli-bridge
+          image: minio/mc
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MINIO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.captain.secret.minio.secretName }}
+                  key: capt-minio-user
+            - name: MINIO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.captain.secret.minio.secretName }}
+                  key: capt-minio-password
+          command:
+            [
+              "sh",
+              "-c",
+              "mc alias set m http://minio.$(NAMESPACE).svc.cluster.local:9000 $MINIO_USER $MINIO_PASSWORD; until mc ls m/intelli-bridge/; do echo $(date) waiting... && sleep 1; done;"
+            ]
         - name: captain-init-rabbitmq
           image: {{ include "rabbitmq-test-client.image" . }}
           env:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Introduce captain-init-minio-bucket-intelli-bridge init container to poll the MinIO service until the 'intelli-bridge' bucket is available before starting the application