### PR TITLE
build: Release chart/agh3 `v3.11.8`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.11.7
+version: 3.11.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -569,7 +569,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.14.1
+    tag: v1.14.3
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -599,7 +599,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.14.1
+    tag: v1.14.3
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -777,7 +777,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.12.11
+    tag: v1.12.12
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.11.8`
- App Version: `3.10.4`
  - ActionLoop: `v1.14.3`
  - Captain: `v1.14.3`
  - Controller: `v1.0.0`
  - UI: `v1.12.12`
  - Report: `v1.1.4`

## Summary by Sourcery

Bump the agh3 Helm chart to version 3.11.8 and update component image tags

Enhancements:
- Update ActionLoop image tag to v1.14.3
- Update Captain image tag to v1.14.3
- Update UI image tag to v1.12.12

Build:
- Increment Chart version to 3.11.8