### PR TITLE
build: update activeStatus field in v2 actions CRD to enable served

### DIFF
--- a/charts/agh3/crds/actions.crds.yaml
+++ b/charts/agh3/crds/actions.crds.yaml
@@ -861,9 +861,9 @@ spec:
                 - activeStatus
               type: object
           type: object
-      served: false
+      served: true
       storage: false
-      deprecated: true
+      deprecated: false
       subresources:
         status: {}
     - additionalPrinterColumns:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Enable serving of the activeStatus field in the v2 actions CRD and un-deprecate it