### PR TITLE
build: Release chart/agh3 `v3.11.11`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.11.10
+version: 3.11.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.10.5"
+appVersion: "v3.10.6"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -569,7 +569,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.14.4
+    tag: v1.14.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -599,7 +599,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.14.4
+    tag: v1.14.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain


### PR DESCRIPTION
- Chart Version: `3.11.11`
- App Version: `3.10.6`
  - ActionLoop: `v1.14.5`
  - Captain: `v1.14.5`
  - Controller: `v1.0.0`
  - UI: `v1.12.12`
  - Report: `v1.1.4`

## Summary by Sourcery

Release agh3 Helm chart v3.11.11 with updated application and service image versions

Enhancements:
- Update container images for ActionLoop (v1.14.5), Captain (v1.14.5), Controller (v1.0.0), UI (v1.12.12), and Report (v1.1.4)

Build:
- Bump Helm chart version to 3.11.11 and appVersion to v3.10.6