### PR TITLE
build: Release chart/agh3 `v3.12.1`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.0
+version: 3.12.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -801,7 +801,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v1.1.0
+    tag: v1.0.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller
@@ -882,7 +882,6 @@ report:
   ## @param report.extraEnv UI additional environment variables
   ##
   extraEnv: {}
-
 ## @section cluster-feature-enabler parameters
 clusterFeatureEnabler:
   ## @param clusterFeatureEnabler.enabled Enable Cluster Feature Enabler module
@@ -904,7 +903,6 @@ clusterFeatureEnabler:
   serviceAccount:
     create: true
     name: cluster-feature-enabler-sa
-
   jobs:
     ## @param clusterFeatureEnabler.jobs.sidecarContainers.enabled Enable Sidecar Containers feature enabler job
     sidecarContainers:


### PR DESCRIPTION
- Chart Version: `3.12.1`
- App Version: `3.11.0`
  - ActionLoop: `v1.14.6`
  - Captain: `v1.14.6`
  - Controller: `v1.0.0`
  - UI: `v1.12.12`
  - Report: `v1.1.4`

## Summary by Sourcery

Bump the agh3 Helm chart to version 3.12.1 and update the controller image tag to match the new application version.

Enhancements:
- Update chart version from 3.12.0 to 3.12.1
- Set controller image tag to v1.0.0