### PR TITLE
fix: AGH-707 Must use image from helper macro to ensure image combined with global registry values.

### DIFF
--- a/charts/agh3/templates/_helpers.tpl
+++ b/charts/agh3/templates/_helpers.tpl
@@ -264,7 +264,7 @@ Return the name of the service account to use for the cluster-feature-enabler
 Return the proper clusterFeatureEnabler image name
 */}}
 {{- define "clusterFeatureEnabler.image" -}}
-{{- include "common.images.image" (dict "imageRoot" .Values.clusterFeatureEnabler.job.image "global" .Values.global) }}
+{{- include "common.images.image" (dict "imageRoot" .Values.clusterFeatureEnabler.image "global" .Values.global) }}
 {{- end }}
 
 {{/*

--- a/charts/agh3/templates/hooks/post/sidecar-container-enabler/50-sidecar-container-feature-enabler.job.yml
+++ b/charts/agh3/templates/hooks/post/sidecar-container-enabler/50-sidecar-container-feature-enabler.job.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: sidecar-containers-feature-enabler
-          image: docker/bitnami/kubectl:1.28
+          image: {{ include "clusterFeatureEnabler.image" . }}
           imagePullPolicy: IfNotPresent
           command:
             [


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace hard-coded kubectl image with Helm helper macro for correct registry integration.


Related Jira tasks:
- AGH-707