### PR TITLE
build: Release chart/agh3 `v3.12.2`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.1
+version: 3.12.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
- Chart Version: `3.12.2`
- App Version: `3.11.0`
  - ActionLoop: `v1.14.6`
  - Captain: `v1.14.6`
  - Controller: `v1.0.0`
  - UI: `v1.12.12`
  - Report: `v1.1.4`

## Summary by Sourcery

Release the AGH3 Helm chart v3.12.2 by updating the chart version and rolling out the latest application and component versions.

Enhancements:
- Update application version to v3.11.0 with ActionLoop and Captain at v1.14.6, Controller at v1.0.0, UI at v1.12.12, and Report at v1.1.4

Build:
- Bump Helm chart version to v3.12.2