### PR TITLE
feat: Generate AI API Host env for Playground.

### DIFF
--- a/charts/playground/templates/playground-deployment.yml
+++ b/charts/playground/templates/playground-deployment.yml
@@ -28,6 +28,8 @@ spec:
               value: {{ include "playground.apiEndpoint" . }}
             - name: AI_API_ENDPOINT
               value: {{ required "playground.service.ai.endpoint is required" .Values.playground.service.ai.endpoint | quote }}
+            - name: AI_API_HOST
+              value: {{ .Values.playground.service.ai.endpoint | trimPrefix "http://" | trimPrefix "https://" | trimSuffix "/" | quote }}
             {{- if .Values.playground.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.playground.extraEnv "context" $) | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Add AI_API_HOST environment variable to the Playground Helm chart by trimming protocol prefixes and trailing slashes from the AI API endpoint