### PR TITLE
build: Release chart/agh3-playground `v1.6.5`

### DIFF
--- a/charts/playground/Chart.yaml
+++ b/charts/playground/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.4
+version: 1.6.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.6.4"
+appVersion: "v1.6.5"
 dependencies:
   - name: common
     version: 2.19.1

--- a/charts/playground/values.yaml
+++ b/charts/playground/values.yaml
@@ -74,7 +74,7 @@ playground:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-playground
-    tag: v1.6.4
+    tag: v1.6.5
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param playground.secret.enabled Enable secret generate for Playground


### PR DESCRIPTION
- Chart Version: `1.6.5`
- App Version: `1.6.5`
  - Playground: `v1.6.5`

## Summary by Sourcery

Bump the playground Helm chart version and application image to v1.6.5

Build:
- Update Chart.yaml version to 1.6.5
- Update appVersion to v1.6.5 in Chart.yaml
- Update image tag to v1.6.5 in values.yaml