### PR TITLE
fix: Update actionloop deployment configuration to include SMTP settings and keygen URL

### DIFF
--- a/charts/agh3/templates/actionloop/actionloop-deployment.yml
+++ b/charts/agh3/templates/actionloop/actionloop-deployment.yml
@@ -112,6 +112,12 @@ spec:
                   key: "RABBITMQ_CONN_STR"
             - name: "APP_VERSION"
               value: {{ .Chart.AppVersion | quote }}
+            {{- if .Values.postfix.enabled }}
+            - name: SMTP_HOST
+              value: "postfix.$(NAMESPACE).svc.cluster.local"
+            - name: SMTP_PORT
+              value: {{ .Values.postfix.service.port | quote }}
+            {{- end }}
             - name: KEYGEN_URL
               value: {{ .Values.keygen.url | default "https://api.keygen.sh"}}
             - name: MINIO_URL


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Inject SMTP_HOST and SMTP_PORT environment variables into the actionloop deployment when postfix is enabled