### PR TITLE
build: Release chart/agh3 `v3.12.4`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.3
+version: 3.12.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -624,7 +624,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.14.7
+    tag: v1.15.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -654,7 +654,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.14.7
+    tag: v1.15.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -853,7 +853,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.12.14
+    tag: v1.13.0
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables
@@ -876,7 +876,7 @@ report:
   ##
   image:
     repository: leukocyte-lab/argushack3/report
-    tag: v1.1.4
+    tag: v1.2.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param report.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.4`
- App Version: `3.11.1`
  - ActionLoop: `v1.15.0`
  - Captain: `v1.15.0`
  - Controller: `v1.0.0`
  - UI: `v1.13.0`
  - Report: `v1.2.1`

## Summary by Sourcery

Release agh3 Helm chart v3.12.4 with updated application version and component images

Enhancements:
- Bump Helm chart version to 3.12.4 and app version to 3.11.1
- Update ActionLoop and Captain container images to v1.15.0
- Update UI container image to v1.13.0
- Update Report container image to v1.2.1