### PR TITLE
feat: update values.yaml to include new report-setting buckets when provisioning

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -385,6 +385,7 @@ minio:
         versioning: true
       - name: packet
       - name: integration
+      - name: report-setting
     ## @skip minio.provisioning.policies
     ## @skip minio.provisioning.usersExistingSecrets
     ##


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Include a 'report-setting' bucket in the default MinIO provisioning values