### PR TITLE
build: Release chart/agh3 `v3.12.6`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.5
+version: 3.12.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -625,7 +625,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.15.0
+    tag: v1.15.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -655,7 +655,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.15.0
+    tag: v1.15.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -854,7 +854,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.0
+    tag: v1.13.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables
@@ -877,7 +877,7 @@ report:
   ##
   image:
     repository: leukocyte-lab/argushack3/report
-    tag: v1.2.1
+    tag: v1.2.3
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param report.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.6`
- App Version: `3.11.1`
  - ActionLoop: `v1.15.1`
  - Captain: `v1.15.1`
  - Controller: `v1.2.0`
  - UI: `v1.13.4`
  - Report: `v1.2.3`

## Summary by Sourcery

Bump agh3 Helm chart version and update component image tags to latest patch releases

Enhancements:
- Update ActionLoop, Captain, UI, and Report container images to their respective v1.15.1, v1.15.1, v1.13.4, and v1.2.3 versions

Build:
- Increment Helm chart version to 3.12.6