### PR TITLE
build: Release chart/agh3 `v3.12.8`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.7
+version: 3.12.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.11.1"
+appVersion: "v3.11.2"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -854,7 +854,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.6
+    tag: v1.13.7
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.8`
- App Version: `3.11.2`
  - ActionLoop: `v1.15.3`
  - Captain: `v1.15.3`
  - Controller: `v1.2.0`
  - UI: `v1.13.7`
  - Report: `v1.2.5`

## Summary by Sourcery

Release agh3 Helm chart 3.12.8 with updated application version and UI image tag

Enhancements:
- Update UI container image tag to v1.13.7

Build:
- Bump chart version to 3.12.8 and appVersion to v3.11.2