### PR TITLE
build: Release chart/agh3 `v3.12.9`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.8
+version: 3.12.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -625,7 +625,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.15.3
+    tag: v1.15.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -655,7 +655,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.15.3
+    tag: v1.15.4
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -854,7 +854,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.7
+    tag: v1.13.8
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables
@@ -877,7 +877,7 @@ report:
   ##
   image:
     repository: leukocyte-lab/argushack3/report
-    tag: v1.2.5
+    tag: v1.2.6
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param report.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.9`
- App Version: `3.11.2`
  - ActionLoop: `v1.15.4`
  - Captain: `v1.15.4`
  - Controller: `v1.2.0`
  - UI: `v1.13.8`
  - Report: `v1.2.6`

## Summary by Sourcery

Release agh3 Helm chart version 3.12.9 with updated component image tags

Enhancements:
- Update ActionLoop image tag to v1.15.4
- Update Captain image tag to v1.15.4
- Update UI image tag to v1.13.8
- Update Report image tag to v1.2.6

Build:
- Bump chart version to 3.12.9