### PR TITLE
feat: add ai review bucket

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -390,6 +390,7 @@ minio:
       - name: packet
       - name: integration
       - name: report-setting
+      - name: review
     ## @skip minio.provisioning.policies
     ## @skip minio.provisioning.usersExistingSecrets
     ##
@@ -413,6 +414,8 @@ minio:
               - "arn:aws:s3:::embedding"
               - "arn:aws:s3:::integration/*"
               - "arn:aws:s3:::integration"
+              - "arn:aws:s3:::review/*"
+              - "arn:aws:s3:::review"
             actions:
               - "s3:GetBucketLocation"
               - "s3:PutObject"


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'review' bucket to the MinIO Helm chart and include it in the S3 provisioning policies

New Features:
- Introduce a 'review' bucket entry in the MinIO chart values

Enhancements:
- Extend S3 provisioning policies to grant access to the 'review' bucket