### PR TITLE
build: Release chart/agh3 `v3.13.1`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.13.0
+version: 3.13.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -964,8 +964,6 @@ grafana:
   ## @param grafana.fullnameOverride Fullname override for Grafana
   ##
   fullnameOverride: grafana
-
-
 ## @section Grafana Tempo parameters
 ## @descriptionStart
 ## Grafana Tempo distributed tracing backend.
@@ -1029,7 +1027,6 @@ grafana-tempo:
   ## @param grafana-tempo.fullnameOverride Fullname override for Grafana Tempo
   ##
   fullnameOverride: grafana-tempo
-
 ## @section Grafana Loki parameters
 ## @descriptionStart
 ## Grafana Loki log aggregation system.
@@ -1088,7 +1085,6 @@ grafana-loki:
   ## @param grafana-loki.fullnameOverride Fullname override for Grafana Loki
   ##
   fullnameOverride: grafana-loki
-
 ## @section Memcached parameters
 ## @descriptionStart
 ## Memcached distributed caching system.


### PR DESCRIPTION
- Chart Version: `3.13.1`
- App Version: `3.12.0`
  - ActionLoop: `v1.15.7`
  - Captain: `v1.15.7`
  - Controller: `v1.2.0`
  - UI: `v1.13.8`
  - Report: `v1.2.6`

## Summary by Sourcery

Release agh3 chart version 3.13.1 and clean up values file formatting

Build:
- Bump agh3 chart version from 3.13.0 to 3.13.1

Chores:
- Remove redundant blank lines in values.yaml