### PR TITLE
Disable initChownData by default

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -949,6 +949,7 @@ grafana:
   ## @param grafana.initChownData.image.repository Init container image repository for setting data directory ownership
   ##
   initChownData:
+    enabled: false
     image:
       repository: docker/busybox
   ## @param grafana.downloadDashboardsImage.repository Image repository used to download dashboards


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add `enabled: false` under `grafana.initChownData` in values.yaml to turn off the initChownData container by default