### PR TITLE
build: Release chart/agh3 `v3.13.4`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.13.3
+version: 3.13.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.12.0"
+appVersion: "v3.12.1"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -632,7 +632,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.15.7
+    tag: v1.15.8
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -662,7 +662,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.15.7
+    tag: v1.15.8
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -861,7 +861,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.8
+    tag: v1.13.10
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.13.4`
- App Version: `3.12.1`
  - ActionLoop: `v1.15.8`
  - Captain: `v1.15.8`
  - Controller: `v1.2.0`
  - UI: `v1.13.10`
  - Report: `v1.2.6`

## Summary by Sourcery

Release agh3 Helm chart version 3.13.4 with application version 3.12.1 and updated component images

Build:
- Bump Helm chart version to 3.13.4 and appVersion to v3.12.1

Chores:
- Update actionLoop and Captain container images to v1.15.8
- Update UI container image to v1.13.10