### PR TITLE
build!: AGH-993 Migrate all bitnami chart to use Bitnami Legacy, due to their new registry policy.

### DIFF
--- a/.github/workflows/agh2-values.template
+++ b/.github/workflows/agh2-values.template
@@ -243,7 +243,7 @@ minio:
   ## @param minio.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/minio
+    repository: docker/bitnamilegacy/minio
     tag: 2023.3.24
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -255,7 +255,7 @@ minio:
   ## @param minio.clientImage.pullSecrets Specify docker-registry secret names as an array
   ##
   clientImage:
-    repository: docker/bitnami/minio-client
+    repository: docker/bitnamilegacy/minio-client
     tag: 2023.4.12
     pullPolicy: IfNotPresent
     pullSecrets: []

--- a/charts/agh2/README.md
+++ b/charts/agh2/README.md
@@ -114,11 +114,11 @@ Leave as default if using external DB
 | Name                              | Description                                               | Value                         |
 | --------------------------------- | --------------------------------------------------------- | ----------------------------- |
 | `minio.internal.enabled`          | Enable internal minio                                     | `true`                        |
-| `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnami/minio`        |
+| `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnamilegacy/minio`        |
 | `minio.image.tag`                 | Internal MinIO image tag (immutable tags are recommended) | `2023.3.24`                   |
 | `minio.image.pullPolicy`          | Internal MinIO image pull policy                          | `IfNotPresent`                |
 | `minio.image.pullSecrets`         | Specify docker-registry secret names as an array          | `[]`                          |
-| `minio.clientImage.repository`    | Internal MinIO image repository                           | `docker/bitnami/minio-client` |
+| `minio.clientImage.repository`    | Internal MinIO image repository                           | `docker/bitnamilegacy/minio-client` |
 | `minio.clientImage.tag`           | Internal MinIO image tag (immutable tags are recommended) | `2023.4.12`                   |
 | `minio.clientImage.pullPolicy`    | Internal MinIO image pull policy                          | `IfNotPresent`                |
 | `minio.clientImage.pullSecrets`   | Specify docker-registry secret names as an array          | `[]`                          |

--- a/charts/agh2/values.yaml
+++ b/charts/agh2/values.yaml
@@ -243,7 +243,7 @@ minio:
   ## @param minio.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/minio
+    repository: docker/bitnamilegacy/minio
     tag: 2023.3.24
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -255,7 +255,7 @@ minio:
   ## @param minio.clientImage.pullSecrets Specify docker-registry secret names as an array
   ##
   clientImage:
-    repository: docker/bitnami/minio-client
+    repository: docker/bitnamilegacy/minio-client
     tag: 2023.4.12
     pullPolicy: IfNotPresent
     pullSecrets: []

--- a/charts/agh3/README.md
+++ b/charts/agh3/README.md
@@ -123,7 +123,7 @@ Leave as default if using external DB
 | Name                                         | Description                                                   | Value                                           |
 | -------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------- |
 | `postgresql.enabled`                         | Enable internal database                                      | `true`                                          |
-| `postgresql.image.repository`                | Internal database image repository                            | `docker/bitnami/postgresql`                     |
+| `postgresql.image.repository`                | Internal database image repository                            | `docker/bitnamilegacy/postgresql`                     |
 | `postgresql.image.tag`                       | Internal database image tag (immutable tags are recommended)  | `15`                                            |
 | `postgresql.image.pullPolicy`                | Internal database image pull policy                           | `IfNotPresent`                                  |
 | `postgresql.image.pullSecrets`               | Specify docker-registry secret names as an array              | `[]`                                            |
@@ -158,11 +158,11 @@ Leave as default if using external DB
 | Name                              | Description                                               | Value                         |
 | --------------------------------- | --------------------------------------------------------- | ----------------------------- |
 | `minio.internal.enabled`          | Enable internal minio                                     | `true`                        |
-| `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnami/minio`        |
+| `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnamilegacy/minio`        |
 | `minio.image.tag`                 | Internal MinIO image tag (immutable tags are recommended) | `2023.3.24`                   |
 | `minio.image.pullPolicy`          | Internal MinIO image pull policy                          | `IfNotPresent`                |
 | `minio.image.pullSecrets`         | Specify docker-registry secret names as an array          | `[]`                          |
-| `minio.clientImage.repository`    | Internal MinIO image repository                           | `docker/bitnami/minio-client` |
+| `minio.clientImage.repository`    | Internal MinIO image repository                           | `docker/bitnamilegacy/minio-client` |
 | `minio.clientImage.tag`           | Internal MinIO image tag (immutable tags are recommended) | `2023.4.12`                   |
 | `minio.clientImage.pullPolicy`    | Internal MinIO image pull policy                          | `IfNotPresent`                |
 | `minio.clientImage.pullSecrets`   | Specify docker-registry secret names as an array          | `[]`                          |
@@ -176,7 +176,7 @@ Leave as default if using external DB
 | Name                                   | Description                                                      | Value                  |
 | -------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
 | `redis.enabled`                        | Enable internal redis                                            | `true`                 |
-| `redis.image.repository`               | Internal Redis image repository                                  | `docker/bitnami/redis` |
+| `redis.image.repository`               | Internal Redis image repository                                  | `docker/bitnamilegacy/redis` |
 | `redis.image.tag`                      | Internal Redis image tag (immutable tags are recommended)        | `7.4.0`                |
 | `redis.image.pullPolicy`               | Internal Redis image pull policy                                 | `IfNotPresent`         |
 | `redis.image.pullSecrets`              | Specify docker-registry secret names as an array                 | `[]`                   |
@@ -207,7 +207,7 @@ Leave as default if using external RabbitMQ
 | Name                         | Description                                                  | Value                     |
 | ---------------------------- | ------------------------------------------------------------ | ------------------------- |
 | `rabbitmq.internal.enabled`  | Enable internal rabbitmq                                     | `true`                    |
-| `rabbitmq.image.repository`  | Internal RabbitMQ image repository                           | `docker/bitnami/rabbitmq` |
+| `rabbitmq.image.repository`  | Internal RabbitMQ image repository                           | `docker/bitnamilegacy/rabbitmq` |
 | `rabbitmq.image.tag`         | Internal RabbitMQ image tag (immutable tags are recommended) | `3.12.13-debian-12-r2`    |
 | `rabbitmq.image.pullPolicy`  | Internal RabbitMQ image pull policy                          | `IfNotPresent`            |
 | `rabbitmq.image.pullSecrets` | Specify docker-registry secret names as an array             | `[]`                      |
@@ -361,12 +361,12 @@ ref: https://artifacthub.io/packages/helm/bitnami/grafana-tempo
 | Name                                                 | Description                                                                 | Value                                 |
 | ---------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
 | `grafana-tempo.enabled`                              | Enable Grafana Tempo                                                        | `false`                               |
-| `grafana-tempo.image.repository`                     | Tempo main image repository                                                 | `docker/bitnami/grafana-tempo`        |
-| `grafana-tempo.tempo.image.repository`               | Tempo OTLP image repository                                                 | `docker/bitnami/grafana-tempo`        |
+| `grafana-tempo.image.repository`                     | Tempo main image repository                                                 | `docker/bitnamilegacy/grafana-tempo`        |
+| `grafana-tempo.tempo.image.repository`               | Tempo OTLP image repository                                                 | `docker/bitnamilegacy/grafana-tempo`        |
 | `grafana-tempo.tempo.traces.otlp.grpc`               | Enable gRPC OTLP ingestion                                                  | `true`                                |
-| `grafana-tempo.queryFrontend.image.repository`       | Tempo query frontend image repository                                       | `docker/bitnami/grafana-tempo-query`  |
-| `grafana-tempo.vulture.image.repository`             | Tempo vulture image repository                                              | `docker/bitnami/grafana-tempo-vulture`|
-| `grafana-tempo.volumePermissions.image.repository`   | Image for volume permission setup                                           | `docker/bitnami/os-shell`             |
+| `grafana-tempo.queryFrontend.image.repository`       | Tempo query frontend image repository                                       | `docker/bitnamilegacy/grafana-tempo-query`  |
+| `grafana-tempo.vulture.image.repository`             | Tempo vulture image repository                                              | `docker/bitnamilegacy/grafana-tempo-vulture`|
+| `grafana-tempo.volumePermissions.image.repository`   | Image for volume permission setup                                           | `docker/bitnamilegacy/os-shell`             |
 | `grafana-tempo.volumePermissions.image.tag`          | Image tag for volume permission setup                                       | `12-debian-12-r49`                    |
 | `grafana-tempo.ingester.resources.requests.memory`   | Ingester memory requests                                                    | `"512Mi"`                             |
 | `grafana-tempo.ingester.resources.requests.cpu`      | Ingester CPU requests                                                       | `"250m"`                              |
@@ -385,11 +385,11 @@ ref: https://artifacthub.io/packages/helm/bitnami/grafana-loki
 | Name                                                      | Description                                                             | Value                                  |
 | --------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------- |
 | `grafana-loki.enabled`                                    | Enable Grafana Loki                                                     | `false`                                |
-| `grafana-loki.loki.image.repository`                      | Loki image repository                                                   | `docker/bitnami/grafana-loki`          |
+| `grafana-loki.loki.image.repository`                      | Loki image repository                                                   | `docker/bitnamilegacy/grafana-loki`          |
 | `grafana-loki.loki.image.tag`                             | Loki image tag                                                          | `3.5.3-debian-12-r0`                   |
-| `grafana-loki.gateway.image.repository`                   | Loki gateway image repository                                           | `docker/bitnami/nginx`                 |
+| `grafana-loki.gateway.image.repository`                   | Loki gateway image repository                                           | `docker/bitnamilegacy/nginx`                 |
 | `grafana-loki.gateway.image.tag`                          | Loki gateway image tag                                                  | `1.29.0-debian-12-r5`                  |
-| `grafana-loki.volumePermissions.image.repository`         | Volume permission image repository                                      | `docker/bitnami/os-shell`              |
+| `grafana-loki.volumePermissions.image.repository`         | Volume permission image repository                                      | `docker/bitnamilegacy/os-shell`              |
 | `grafana-loki.volumePermissions.image.tag`                | Volume permission image tag                                             | `12-debian-12-r49`                     |
 | `grafana-loki.grafanaalloy.enabled`                       | Enable Grafana Alloy integration                                        | `false`                                |
 | `grafana-loki.memcachedchunks.enabled`                    | Enable Memcached for chunks caching                                     | `false`                                |
@@ -408,6 +408,6 @@ ref: https://artifacthub.io/packages/helm/bitnami/memcached
 | Name                           | Description                    | Value                                 |
 | ------------------------------ | ------------------------------ | ------------------------------------- |
 | `memcached.enabled`            | Enable Memcached               | `false`                               |
-| `memcached.image.repository`   | Memcached image repository     | `docker/bitnami/memcached`            |
+| `memcached.image.repository`   | Memcached image repository     | `docker/bitnamilegacy/memcached`            |
 | `memcached.image.tag`          | Memcached image tag            | `1.6.39-debian-12-r0`                 |
 

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -54,7 +54,7 @@ crds:
   job:
     name: actions-crd-job
     image:
-      repository: docker/bitnami/kubectl
+      repository: docker/bitnamilegacy/kubectl
       tag: 1.28.15-debian-12-r5
       pullPolicy: IfNotPresent
       pullSecrets: []
@@ -244,7 +244,7 @@ postgresql:
   ## @param postgresql.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/postgresql
+    repository: docker/bitnamilegacy/postgresql
     tag: 15.7.0
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -329,7 +329,7 @@ minio:
   ## @param minio.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/minio
+    repository: docker/bitnamilegacy/minio
     tag: 2024.11.7-debian-12-r2
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -340,7 +340,7 @@ minio:
   ## @param minio.clientImage.pullSecrets Specify docker-registry secret names as an array
   ##
   clientImage:
-    repository: docker/bitnami/minio-client
+    repository: docker/bitnamilegacy/minio-client
     tag: 2024.11.17-debian-12-r1
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -471,7 +471,7 @@ redis:
     ## @param redis.image.tag Internal Redis image tag (immutable tags are recommended)
     ## @param redis.image.pullPolicy Internal Redis image pull policy
     ## @param redis.image.pullSecrets Specify docker-registry secret names as an array
-    repository: docker/bitnami/redis
+    repository: docker/bitnamilegacy/redis
     tag: 7.4.0
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -558,7 +558,7 @@ rabbitmq:
   ## @param rabbitmq.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/rabbitmq
+    repository: docker/bitnamilegacy/rabbitmq
     tag: 3.12.13-debian-12-r2
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -902,7 +902,7 @@ clusterFeatureEnabler:
   ## @param clusterFeatureEnabler.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    repository: docker/bitnami/kubectl
+    repository: docker/bitnamilegacy/kubectl
     tag: "1.28.15-debian-12-r5"
     pullPolicy: IfNotPresent
     pullSecrets: []
@@ -977,12 +977,12 @@ grafana-tempo:
   ##
   enabled: false
   image:
-    repository: docker/bitnami/grafana-tempo
+    repository: docker/bitnamilegacy/grafana-tempo
   tempo:
     ## @param grafana-tempo.tempo.image.repository Tempo image repository
     ##
     image:
-      repository: docker/bitnami/grafana-tempo
+      repository: docker/bitnamilegacy/grafana-tempo
     traces:
       otlp:
         grpc: true
@@ -990,17 +990,17 @@ grafana-tempo:
     ## @param grafana-tempo.queryFrontend.image.repository Tempo query frontend image repository
     ##
     image:
-      repository: docker/bitnami/grafana-tempo-query
+      repository: docker/bitnamilegacy/grafana-tempo-query
   vulture:
     ## @param grafana-tempo.vulture.image.repository Tempo vulture image repository
     ##
     image:
-      repository: docker/bitnami/grafana-tempo-vulture
+      repository: docker/bitnamilegacy/grafana-tempo-vulture
   volumePermissions:
     ## @param grafana-tempo.volumePermissions.image.repository Image repository for setting volume permissions
     ##
     image:
-      repository: docker/bitnami/os-shell
+      repository: docker/bitnamilegacy/os-shell
       tag: 12-debian-12-r49
   ## @param grafana-tempo.ingester.resources.requests.memory Ingester memory requests
   ## @param grafana-tempo.ingester.resources.requests.cpu Ingester CPU requests
@@ -1044,21 +1044,21 @@ grafana-loki:
     ## @param grafana-loki.loki.image.tag Loki image tag (immutable tags are recommended)
     ##
     image:
-      repository: docker/bitnami/grafana-loki
+      repository: docker/bitnamilegacy/grafana-loki
       tag: 3.5.3-debian-12-r0
   gateway:
     ## @param grafana-loki.gateway.image.repository Loki gateway image repository
     ## @param grafana-loki.gateway.image.tag Loki gateway image tag
     ##
     image:
-      repository: docker/bitnami/nginx
+      repository: docker/bitnamilegacy/nginx
       tag: 1.29.0-debian-12-r5
   volumePermissions:
     ## @param grafana-loki.volumePermissions.image.repository Image repository for setting volume permissions
     ## @param grafana-loki.volumePermissions.image.tag Image tag for setting volume permissions
     ##
     image:
-      repository: docker/bitnami/os-shell
+      repository: docker/bitnamilegacy/os-shell
       tag: 12-debian-12-r49
   ## @param grafana-loki.grafanaalloy.enabled Enable integration with Grafana Alloy
   ##
@@ -1096,7 +1096,7 @@ grafana-loki:
 memcached:
   enabled: false
   image:
-    repository: docker/bitnami/memcached
+    repository: docker/bitnamilegacy/memcached
     tag: 1.6.39-debian-12-r0
   ## @param memcached.fullnameOverride Fullname override for Memcached
   ##


### PR DESCRIPTION
Ref: bitnami/charts#35164

## Summary by Sourcery

Migrate all Bitnami image references to use Bitnami Legacy registry due to Bitnami’s new registry policy

Enhancements:
- Replace all docker/bitnami image repository references with docker/bitnamilegacy in chart values files

Documentation:
- Update chart README defaults to reflect Bitnami Legacy image repositories