### PR TITLE
build: Release chart/agh3 `v3.12.12`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.11
+version: 3.12.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -802,7 +802,7 @@ controller:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-controller
-    tag: v1.2.0
+    tag: v1.3.1
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param controller.secret.enabled Enable secret generate for Controller
@@ -854,7 +854,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.10
+    tag: v1.13.13
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.12`
- App Version: `3.11.3`
  - ActionLoop: `v1.15.8`
  - Captain: `v1.15.8`
  - Controller: `v1.3.1`
  - UI: `v1.13.13`
  - Report: `v1.2.6`

## Summary by Sourcery

Bump the agh3 Helm chart to version 3.12.12 and update controller and UI container images to their new releases

Enhancements:
- Upgrade controller image tag to v1.3.1
- Upgrade UI image tag to v1.13.13

Build:
- Increment Helm chart version to 3.12.12