### PR TITLE
ci: add release branch to trigger auto release chart

### DIFF
--- a/.github/workflows/agh3-auto-release.yaml
+++ b/.github/workflows/agh3-auto-release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - orphan/**
+      - release/**
     paths:
       - charts/agh3/**
       - .github/workflows/agh3-auto-release.yaml


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add release/** branch pattern to trigger auto release chart