### PR TITLE
fix: add multi part upload permission to ai policy

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -423,6 +423,9 @@ minio:
               - "s3:GetObject"
               - "s3:ListBucket"
               - "s3:HeadBucket"
+              - "s3:ListMultipartUploadParts"
+              - "s3:AbortMultipartUpload"
+              - "s3:ListBucketMultipartUploads"
       - name: agh-packet-policy
         statements:
           - effect: "Allow"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add S3 multipart upload permissions (ListMultipartUploadParts, AbortMultipartUpload, ListBucketMultipartUploads) to the MinIO policy in the agh3 chart