### PR TITLE
fix: add multi part upload permission to ai policy

### DIFF
--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -415,6 +415,9 @@ minio:
               - "s3:GetObject"
               - "s3:ListBucket"
               - "s3:HeadBucket"
+              - "s3:ListMultipartUploadParts"
+              - "s3:AbortMultipartUpload"
+              - "s3:ListBucketMultipartUploads"
       - name: agh-packet-policy
         statements:
           - effect: "Allow"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include s3:ListMultipartUploadParts, s3:AbortMultipartUpload, and s3:ListBucketMultipartUploads in the MinIO policy to restore multipart support