### PR TITLE
fix: attach new policy and detach old one

### DIFF
--- a/charts/agh3/templates/minio/agh-minio-users-secret.yml
+++ b/charts/agh3/templates/minio/agh-minio-users-secret.yml
@@ -68,7 +68,7 @@ stringData:
     {{- with index .Values.minio.provisioning.policies 1 }}
     policies={{ .name }}
     {{- end }}
-    setPolicies=false
+    setPolicies=true
   {{ .Values.packet.secret.minio.user }}: |
     username={{ .Values.packet.secret.minio.user }}
     password={{

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -405,7 +405,7 @@ minio:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"
               - "s3:GetObject"
-      - name: agh-parser-policy
+      - name: agh-ai-policy
         statements:
           - effect: "Allow"
             resources:


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic policy assignment for Minio users and switch from the old parser policy to the new AI policy

Bug Fixes:
- Set setPolicies to true in the Minio user secret template to apply policy changes
- Update default policy name from 'agh-parser-policy' to 'agh-ai-policy' in values.yaml