### PR TITLE
Revert "Add minio as loki storage backend"

### DIFF
--- a/.github/workflows/agh3-test.yml
+++ b/.github/workflows/agh3-test.yml
@@ -48,21 +48,6 @@ jobs:
             --set keygen.accountID='ci-test-50e8e2cc-a1ac-4c8d-85e3-f897be4350a0' \
             -n agh
 
-      - name: 🧪 Run chart-testing -> internal mode, enable observability
-        run: |
-          helm dependency build charts/agh3
-          helm template agh charts/agh3 \
-            --set customRegistrySecret.auth.username='robot$ci-test-lkc-lab+foo' \
-            --set customRegistrySecret.auth.password='ci-test-9e1e8ee7-edba-49d9-9cae-2dabf522d4d1' \
-            --set keygen.apiToken='ci-test-f9cef717fa3c' \
-            --set keygen.accountID='ci-test-50e8e2cc-a1ac-4c8d-85e3-f897be4350a0' \
-            --set vector.enabled=true \
-            --set grafana.enabled=true \
-            --set grafana-tempo.enabled=true \
-            --set grafana-loki.enabled=true \
-            --set memcached.enabled=true \
-            -n agh
-
       - name: 🧪 Run chart-testing -> internal mode, storage-system only
         run: |
           helm dependency build charts/agh3

--- a/charts/agh3/README.md
+++ b/charts/agh3/README.md
@@ -37,25 +37,6 @@ helm install agh2 lkclab/agh2
 | `global.storageClass`              | Global storage class for dynamic provisioning                                                                        | `""`   |
 | `global.volumePermissions.enabled` | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `true` |
 
-### Security parameters
-
-| Name                                  | Description                                                                                                | Value  |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------ |
-| `global.security.allowInsecureImages` | Allow unrecognized images, this is be use for `grafana-tempo/charts/memcached/templates/NOTES.txt` warning | `true` |
-
-### crds parameters
-
-| Name                           | Description                 | Value                          |
-| ------------------------------ | --------------------------- | ------------------------------ |
-| `crds.volume.name`             | Name of the volume          | `crd-volume`                   |
-| `crds.job.name`                | Name of the job             | `actions-crd-job`              |
-| `crds.job.image.repository`    | Image repository            | `docker/bitnamilegacy/kubectl` |
-| `crds.job.image.tag`           | Image tag                   | `1.28.15-debian-12-r5`         |
-| `crds.job.image.pullPolicy`    | Image pull policy           | `IfNotPresent`                 |
-| `crds.job.image.pullSecrets`   | Image pull secrets          | `[]`                           |
-| `crds.job.serviceAccount.name` | Name of the service account | `actions-crds-job-sa`          |
-| `crds.cm.name`                 | Name of the config map      | `actions-crd`                  |
-
 ### Common parameters
 
 | Name                                 | Description                                       | Value                  |
@@ -142,8 +123,8 @@ Leave as default if using external DB
 | Name                                         | Description                                                   | Value                                           |
 | -------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------- |
 | `postgresql.enabled`                         | Enable internal database                                      | `true`                                          |
-| `postgresql.image.repository`                | Internal database image repository                            | `docker/bitnamilegacy/postgresql`               |
-| `postgresql.image.tag`                       | Internal database image tag (immutable tags are recommended)  | `15.7.0`                                        |
+| `postgresql.image.repository`                | Internal database image repository                            | `docker/bitnamilegacy/postgresql`                     |
+| `postgresql.image.tag`                       | Internal database image tag (immutable tags are recommended)  | `15`                                            |
 | `postgresql.image.pullPolicy`                | Internal database image pull policy                           | `IfNotPresent`                                  |
 | `postgresql.image.pullSecrets`               | Specify docker-registry secret names as an array              | `[]`                                            |
 | `postgresql.auth.enabled`                    | Enable postgresql auth secret generate                        | `true`                                          |
@@ -174,62 +155,42 @@ shared_buffers = 4GB
 
 Leave as default if using external DB
 
-| Name                                     | Description                                                      | Value                               |
-| ---------------------------------------- | ---------------------------------------------------------------- | ----------------------------------- |
-| `minio.internal.enabled`                 | Enable internal minio                                            | `true`                              |
-| `minio.image.repository`                 | Internal MinIO image repository                                  | `docker/bitnamilegacy/minio`        |
-| `minio.image.tag`                        | Internal MinIO image tag (immutable tags are recommended)        | `2024.11.7-debian-12-r2`            |
-| `minio.image.pullPolicy`                 | Internal MinIO image pull policy                                 | `IfNotPresent`                      |
-| `minio.image.pullSecrets`                | Specify docker-registry secret names as an array                 | `[]`                                |
-| `minio.clientImage.repository`           | Internal MinIO image repository                                  | `docker/bitnamilegacy/minio-client` |
-| `minio.clientImage.tag`                  | Internal MinIO image tag (immutable tags are recommended)        | `2024.11.17-debian-12-r1`           |
-| `minio.clientImage.pullPolicy`           | Internal MinIO image pull policy                                 | `IfNotPresent`                      |
-| `minio.clientImage.pullSecrets`          | Specify docker-registry secret names as an array                 | `[]`                                |
-| `minio.helpers.test.image.repository`    | Minio Connection Test image repository                           | `docker/curlimages/curl`            |
-| `minio.helpers.test.image.tag`           | Minio Connection Test image tag (immutable tags are recommended) | `8.15.0`                            |
-| `minio.helpers.test.image.pullPolicy`    | Minio Connection Test image pull policy                          | `IfNotPresent`                      |
-| `minio.helpers.test.image.pullSecrets`   | Specify docker-registry secret names as an array                 | `[]`                                |
-| `minio.helpers.bucket.image.repository`  | Minio Bucket Test image repository                               | `docker/minio/mc`                   |
-| `minio.helpers.bucket.image.tag`         | Minio Bucket Test image tag(immutable tags are recommended)      | `RELEASE.2025-07-16T15-35-03Z`      |
-| `minio.helpers.bucket.image.pullPolicy`  | Minio Bucket Test image pull policy                              | `IfNotPresent`                      |
-| `minio.helpers.bucket.image.pullSecrets` | Specify docker-registry secret names as an array                 | `[]`                                |
-| `minio.auth.rootUser`                    | Internal database root user                                      | `argushack`                         |
-| `minio.auth.rootPassword`                | Internal database root password                                  | `""`                                |
-| `minio.provisioning.enabled`             | Enable minio provisioning                                        | `true`                              |
-| `minio.provisioning.generateUser`        | Enable minio user generation                                     | `true`                              |
-| `minio.extraEnvVarsCM`                   |                                                                  | `agh-minio-cm`                      |
-| `minio.persistence.mountPath`            | Data volume mount path                                           | `/data`                             |
-
-### Kueue parameters
-
-| Name                      | Description               | Value               |
-| ------------------------- | ------------------------- | ------------------- |
-| `kueue.enabled`           | Enable internal kueue     | `false`             |
-| `kueue.queueName.cluster` | Cluster queue name        | `agh3-cluster-pool` |
-| `kueue.queueName.local`   | Local queue name          | `agh3-local-pool`   |
-| `kueue.concurrentJobs`    | Number of concurrent jobs | `100`               |
+| Name                              | Description                                               | Value                         |
+| --------------------------------- | --------------------------------------------------------- | ----------------------------- |
+| `minio.internal.enabled`          | Enable internal minio                                     | `true`                        |
+| `minio.image.repository`          | Internal MinIO image repository                           | `docker/bitnamilegacy/minio`        |
+| `minio.image.tag`                 | Internal MinIO image tag (immutable tags are recommended) | `2023.3.24`                   |
+| `minio.image.pullPolicy`          | Internal MinIO image pull policy                          | `IfNotPresent`                |
+| `minio.image.pullSecrets`         | Specify docker-registry secret names as an array          | `[]`                          |
+| `minio.clientImage.repository`    | Internal MinIO image repository                           | `docker/bitnamilegacy/minio-client` |
+| `minio.clientImage.tag`           | Internal MinIO image tag (immutable tags are recommended) | `2023.4.12`                   |
+| `minio.clientImage.pullPolicy`    | Internal MinIO image pull policy                          | `IfNotPresent`                |
+| `minio.clientImage.pullSecrets`   | Specify docker-registry secret names as an array          | `[]`                          |
+| `minio.auth.rootUser`             | Internal database root user                               | `argushack`                   |
+| `minio.auth.rootPassword`         | Internal database root password                           | `""`                          |
+| `minio.provisioning.enabled`      | Enable minio provisioning                                 | `true`                        |
+| `minio.provisioning.generateUser` | Enable minio user generation                              | `true`                        |
 
 ### Redis parameters
 
-| Name                                   | Description                                                      | Value                        |
-| -------------------------------------- | ---------------------------------------------------------------- | ---------------------------- |
-| `redis.enabled`                        | Enable internal redis                                            | `true`                       |
+| Name                                   | Description                                                      | Value                  |
+| -------------------------------------- | ---------------------------------------------------------------- | ---------------------- |
+| `redis.enabled`                        | Enable internal redis                                            | `true`                 |
 | `redis.image.repository`               | Internal Redis image repository                                  | `docker/bitnamilegacy/redis` |
-| `redis.image.tag`                      | Internal Redis image tag (immutable tags are recommended)        | `7.4.0`                      |
-| `redis.image.pullPolicy`               | Internal Redis image pull policy                                 | `IfNotPresent`               |
-| `redis.image.pullSecrets`              | Specify docker-registry secret names as an array                 | `[]`                         |
-| `redis.secret.secretName`              | Name of the generated secret                                     | `agh-redis-secret`           |
-| `redis.secret.password`                | Redis password                                                   | `""`                         |
-| `redis.helpers.test.image.repository`  | Redis Connection Test image repository                           | `docker/library/redis`       |
-| `redis.helpers.test.image.tag`         | Redis Connection Test image tag (immutable tags are recommended) | `7-alpine`                   |
-| `redis.helpers.test.image.pullPolicy`  | Redis Connection Test image pull policy                          | `IfNotPresent`               |
-| `redis.helpers.test.image.pullSecrets` | Specify docker-registry secret names as an array                 | `[]`                         |
+| `redis.image.tag`                      | Internal Redis image tag (immutable tags are recommended)        | `7.4.0`                |
+| `redis.image.pullPolicy`               | Internal Redis image pull policy                                 | `IfNotPresent`         |
+| `redis.image.pullSecrets`              | Specify docker-registry secret names as an array                 | `[]`                   |
+| `redis.secret.secretName`              | Name of the generated secret                                     | `agh-redis-secret`     |
+| `redis.secret.password`                | Redis password                                                   | `""`                   |
+| `redis.helpers.test.image.repository`  | Redis Connection Test image repository                           | `docker/library/redis` |
+| `redis.helpers.test.image.tag`         | Redis Connection Test image tag (immutable tags are recommended) | `7-alpine`             |
+| `redis.helpers.test.image.pullPolicy`  | Redis Connection Test image pull policy                          | `IfNotPresent`         |
+| `redis.helpers.test.image.pullSecrets` | Specify docker-registry secret names as an array                 | `[]`                   |
 
 ### RabbitMQ parameters
 
 | Name                           | Description                                          | Value                 |
 | ------------------------------ | ---------------------------------------------------- | --------------------- |
-| `rabbitmq.queueName`           | Name of the RabbitMQ queue                           | `action_crd_result`   |
 | `rabbitmq.connection.type`     | Choose to use external RabbitMQ or internal RabbitMQ | `internal`            |
 | `rabbitmq.connection.protocol` | RabbitMQ protocol                                    | `amqp`                |
 | `rabbitmq.connection.host`     | RabbitMQ host address                                | `mq.example.com`      |
@@ -243,13 +204,13 @@ Leave as default if using external DB
 
 Leave as default if using external RabbitMQ
 
-| Name                         | Description                                                  | Value                           |
-| ---------------------------- | ------------------------------------------------------------ | ------------------------------- |
-| `rabbitmq.internal.enabled`  | Enable internal rabbitmq                                     | `true`                          |
+| Name                         | Description                                                  | Value                     |
+| ---------------------------- | ------------------------------------------------------------ | ------------------------- |
+| `rabbitmq.internal.enabled`  | Enable internal rabbitmq                                     | `true`                    |
 | `rabbitmq.image.repository`  | Internal RabbitMQ image repository                           | `docker/bitnamilegacy/rabbitmq` |
-| `rabbitmq.image.tag`         | Internal RabbitMQ image tag (immutable tags are recommended) | `3.12.13-debian-12-r2`          |
-| `rabbitmq.image.pullPolicy`  | Internal RabbitMQ image pull policy                          | `IfNotPresent`                  |
-| `rabbitmq.image.pullSecrets` | Specify docker-registry secret names as an array             | `[]`                            |
+| `rabbitmq.image.tag`         | Internal RabbitMQ image tag (immutable tags are recommended) | `3.12.13-debian-12-r2`    |
+| `rabbitmq.image.pullPolicy`  | Internal RabbitMQ image pull policy                          | `IfNotPresent`            |
+| `rabbitmq.image.pullSecrets` | Specify docker-registry secret names as an array             | `[]`                      |
 
 ### RabbitMQ service provisioning parameters
 
@@ -275,100 +236,43 @@ Control the DB Helper behaviors.
 | `rabbitmq.helpers.test.image.pullPolicy`  | RabbitMQ Connection Test image pull policy                          | `IfNotPresent`           |
 | `rabbitmq.helpers.test.image.pullSecrets` | Specify docker-registry secret names as an array                    | `[]`                     |
 
-### AGH3-Action-Loop parameters
-
-Action Loop module for AGH3.
-ref: https://github.com/Leukocyte-Lab/AGH3-Captain
-
-| Name                               | Description                                            | Value                                     |
-| ---------------------------------- | ------------------------------------------------------ | ----------------------------------------- |
-| `actionLoop.enabled`               | Enable Action Loop module                              | `true`                                    |
-| `actionLoop.replicaCount`          | Number of Action Loop replicas                         | `3`                                       |
-| `actionLoop.image.repository`      | Action Loop image repository                           | `leukocyte-lab/argushack3/ctr-actionloop` |
-| `actionLoop.image.tag`             | Action Loop image tag (immutable tags are recommended) | `v1.15.7`                                 |
-| `actionLoop.image.pullPolicy`      | Action Loop image pull policy                          | `IfNotPresent`                            |
-| `actionLoop.image.pullSecrets`     | Specify docker-registry secret names as an array       | `[]`                                      |
-| `actionLoop.serviceAccount.create` | Create serviceAccount for Action Loop                  | `true`                                    |
-| `actionLoop.serviceAccount.name`   | Name of the serviceAccount for Action Loop             | `action-loop-sa`                          |
-| `actionLoop.rbac.create`           | Create RBAC for Action Loop                            | `true`                                    |
-
 ### AGH3-Captain parameters
 
 Captain module for AGH3.
 ref: https://github.com/Leukocyte-Lab/AGH3-Captain
 
-| Name                                   | Description                                                                                       | Value                                  |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `captain.enabled`                      | Enable Captain module                                                                             | `true`                                 |
-| `captain.image.repository`             | Captain image repository                                                                          | `leukocyte-lab/argushack3/ctr-captain` |
-| `captain.image.tag`                    | Captain image tag (immutable tags are recommended)                                                | `v1.15.7`                              |
-| `captain.image.pullPolicy`             | Captain image pull policy                                                                         | `IfNotPresent`                         |
-| `captain.image.pullSecrets`            | Specify docker-registry secret names as an array                                                  | `[]`                                   |
-| `captain.secret.enabled`               | Enable secret generate for Captain                                                                | `true`                                 |
-| `captain.secret.db.enabled`            | Enable secret generate for Captain database                                                       | `true`                                 |
-| `captain.secret.db.name`               | Database name                                                                                     | `captain-db`                           |
-| `captain.secret.db.user`               | Database user                                                                                     | `agh-captain`                          |
-| `captain.secret.db.password`           | Database password                                                                                 | `""`                                   |
-| `captain.secret.minio.enabled`         | Enable secret generate for Minio                                                                  | `true`                                 |
-| `captain.secret.minio.secretName`      | Secret name for Minio                                                                             | `capt-minio-secret`                    |
-| `captain.secret.minio.user`            | Minio user                                                                                        | `capt-minio-user`                      |
-| `captain.secret.minio.password`        | Minio password                                                                                    | `""`                                   |
-| `captain.secret.minio.resourcesPreset` | Minio resources preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge) | `small`                                |
-| `captain.secret.jwt.enabled`           | Enable secret generate for JWT                                                                    | `true`                                 |
-| `captain.secret.jwt.secretName`        | Secret name for JWT                                                                               | `capt-jwt-secret`                      |
-| `captain.secret.jwt.secret`            | JWT secret                                                                                        | `""`                                   |
-| `captain.secret.superadmin.enabled`    | Enable secret generate for Super Admin                                                            | `true`                                 |
-| `captain.secret.superadmin.secretName` | Secret name for Super Admin                                                                       | `capt-superadmin-password`             |
-| `captain.secret.superadmin.password`   | Super Admin password                                                                              | `""`                                   |
-| `captain.secret.oidc.enabled`          | Enable secret generate for OIDC                                                                   | `false`                                |
-| `captain.secret.oidc.secretName`       | Secret name for OIDC                                                                              | `capt-oidc-secret`                     |
-| `captain.secret.oidc.url`              | OIDC user                                                                                         | `""`                                   |
-| `captain.secret.oidc.clientID`         | OIDC user                                                                                         | `""`                                   |
-| `captain.secret.oidc.clientSecret`     | OIDC password                                                                                     | `""`                                   |
-| `captain.secret.oidc.realm`            | OIDC realm                                                                                        | `""`                                   |
-| `captain.serviceAccount.create`        | Create serviceAccount for Captain                                                                 | `true`                                 |
-| `captain.serviceAccount.name`          | Name of the serviceAccount for Captain                                                            | `captain-sa`                           |
-| `captain.rbac.create`                  | Create RBAC for Captain                                                                           | `true`                                 |
-| `captain.extraEnv`                     | Captain additional environment variables                                                          | `{}`                                   |
-
-### packet parameters
-
-Packet module for AGH3.
-descriptionEnd
-@param packet.secret.enabled Enable secret generate for packet
-
-@param packet.secret.minio.enabled Enable secret generate for Minio
-@param packet.secret.minio.secretName Secret name for Minio
-@param packet.secret.minio.user Minio user
-@param packet.secret.minio.password Minio password
-
-
-| Name                             | Description                       | Value                 |
-| -------------------------------- | --------------------------------- | --------------------- |
-| `packet.secret.enabled`          | Enable secret generate for packet | `true`                |
-| `packet.secret.minio.enabled`    | Enable secret generate for Minio  | `true`                |
-| `packet.secret.minio.secretName` | Secret name for Minio             | `packet-minio-secret` |
-| `packet.secret.minio.user`       | Minio user                        | `packet-minio-user`   |
-| `packet.secret.minio.password`   | Minio password                    | `""`                  |
-
-### ai-parser parameters
-
-@section ai-parser parameters
-@descriptionStart
-AI Parser module for AGH3.
-
-| Name                             | Description                                       | Value                              |
-| -------------------------------- | ------------------------------------------------- | ---------------------------------- |
-| `parser.secret.enabled`          | Enable secret generate for Parser                 | `true`                             |
-| `parser.secret.minio.enabled`    | Enable secret generate for Minio                  | `true`                             |
-| `parser.secret.minio.secretName` | Secret name for Minio                             | `parser-minio-secret`              |
-| `parser.secret.minio.user`       | Minio user                                        | `parser-minio-user`                |
-| `parser.secret.minio.password`   | Minio password                                    | `""`                               |
-| `parser.secret.sa.enabled`       | Enable secret generate for Parser service account | `false`                            |
-| `parser.secret.sa.secretName`    | Secret name for Parser service account            | `parser-sa-secret`                 |
-| `parser.secret.sa.json`          | Parser service account JSON                       | `{
-  "type": "service_account",
-}` |
+| Name                                   | Description                                        | Value                                  |
+| -------------------------------------- | -------------------------------------------------- | -------------------------------------- |
+| `captain.enabled`                      | Enable Captain module                              | `true`                                 |
+| `captain.image.repository`             | Captain image repository                           | `leukocyte-lab/argushack3/ctr-captain` |
+| `captain.image.tag`                    | Captain image tag (immutable tags are recommended) | `v1.7.6`                               |
+| `captain.image.pullPolicy`             | Captain image pull policy                          | `IfNotPresent`                         |
+| `captain.image.pullSecrets`            | Specify docker-registry secret names as an array   | `[]`                                   |
+| `captain.secret.enabled`               | Enable secret generate for Captain                 | `true`                                 |
+| `captain.secret.db.enabled`            | Enable secret generate for Captain database        | `true`                                 |
+| `captain.secret.db.name`               | Database name                                      | `captain-db`                           |
+| `captain.secret.db.user`               | Database user                                      | `agh-captain`                          |
+| `captain.secret.db.password`           | Database password                                  | `""`                                   |
+| `captain.secret.minio.enabled`         | Enable secret generate for Minio                   | `true`                                 |
+| `captain.secret.minio.secretName`      | Secret name for Minio                              | `capt-minio-secret`                    |
+| `captain.secret.minio.user`            | Minio user                                         | `capt-minio-user`                      |
+| `captain.secret.minio.password`        | Minio password                                     | `""`                                   |
+| `captain.secret.jwt.enabled`           | Enable secret generate for JWT                     | `true`                                 |
+| `captain.secret.jwt.secretName`        | Secret name for JWT                                | `capt-jwt-secret`                      |
+| `captain.secret.jwt.secret`            | JWT secret                                         | `""`                                   |
+| `captain.secret.superadmin.enabled`    | Enable secret generate for Super Admin             | `true`                                 |
+| `captain.secret.superadmin.secretName` | Secret name for Super Admin                        | `capt-superadmin-password`             |
+| `captain.secret.superadmin.password`   | Super Admin password                               | `""`                                   |
+| `captain.secret.oidc.enabled`          | Enable secret generate for OIDC                    | `false`                                |
+| `captain.secret.oidc.secretName`       | Secret name for OIDC                               | `capt-oidc-secret`                     |
+| `captain.secret.oidc.url`              | OIDC user                                          | `""`                                   |
+| `captain.secret.oidc.clientID`         | OIDC user                                          | `""`                                   |
+| `captain.secret.oidc.clientSecret`     | OIDC password                                      | `""`                                   |
+| `captain.secret.oidc.realm`            | OIDC realm                                         | `""`                                   |
+| `captain.serviceAccount.create`        | Create serviceAccount for Captain                  | `true`                                 |
+| `captain.serviceAccount.name`          | Name of the serviceAccount for Captain             | `captain-sa`                           |
+| `captain.rbac.create`                  | Create RBAC for Captain                            | `true`                                 |
+| `captain.extraEnv`                     | Captain additional environment variables           | `{}`                                   |
 
 ### AGH3-Controller parameters
 
@@ -379,7 +283,7 @@ ref: https://github.com/Leukocyte-Lab/AGH3-Controller
 | ------------------------------------ | ----------------------------------------------------- | ----------------------------------------- |
 | `controller.enabled`                 | Enable Controller module                              | `true`                                    |
 | `controller.image.repository`        | Controller image repository                           | `leukocyte-lab/argushack3/ctr-controller` |
-| `controller.image.tag`               | Controller image tag (immutable tags are recommended) | `v1.2.0`                                  |
+| `controller.image.tag`               | Controller image tag (immutable tags are recommended) | `v0.7.2`                                  |
 | `controller.image.pullPolicy`        | Controller image pull policy                          | `IfNotPresent`                            |
 | `controller.image.pullSecrets`       | Specify docker-registry secret names as an array      | `[]`                                      |
 | `controller.secret.enabled`          | Enable secret generate for Controller                 | `true`                                    |
@@ -403,7 +307,7 @@ ref: https://github.com/Leukocyte-Lab/AGH3-UI
 | ---------------------- | ------------------------------------------------ | --------------------------------- |
 | `ui.enabled`           | Enable UI module                                 | `true`                            |
 | `ui.image.repository`  | UI image repository                              | `leukocyte-lab/argushack3/ctr-ui` |
-| `ui.image.tag`         | UI image tag (immutable tags are recommended)    | `v1.13.8`                         |
+| `ui.image.tag`         | UI image tag (immutable tags are recommended)    | `v1.6.12`                         |
 | `ui.image.pullPolicy`  | UI image pull policy                             | `IfNotPresent`                    |
 | `ui.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                              |
 | `ui.extraEnv`          | UI additional environment variables              | `{}`                              |
@@ -417,112 +321,93 @@ ref: https://github.com/Leukocyte-Lab/AGH3-Report
 | -------------------------- | ------------------------------------------------- | --------------------------------- |
 | `report.enabled`           | Enable Report module                              | `true`                            |
 | `report.image.repository`  | Report image repository                           | `leukocyte-lab/argushack3/report` |
-| `report.image.tag`         | Report image tag (immutable tags are recommended) | `v1.2.6`                          |
+| `report.image.tag`         | Report image tag (immutable tags are recommended) | `v1.1.4`                          |
 | `report.image.pullPolicy`  | Report image pull policy                          | `IfNotPresent`                    |
 | `report.image.pullSecrets` | Specify docker-registry secret names as an array  | `[]`                              |
 | `report.extraEnv`          | UI additional environment variables               | `{}`                              |
 
-### cluster-feature-enabler parameters
-
-| Name                                                   | Description                                                        | Value                                |
-| ------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------ |
-| `clusterFeatureEnabler.enabled`                        | Enable Cluster Feature Enabler module                              | `true`                               |
-| `clusterFeatureEnabler.image.repository`               | Cluster Feature Enabler image repository                           | `docker/bitnamilegacy/kubectl`       |
-| `clusterFeatureEnabler.image.tag`                      | Cluster Feature Enabler image tag (immutable tags are recommended) | `1.28.15-debian-12-r5`               |
-| `clusterFeatureEnabler.image.pullPolicy`               | Cluster Feature Enabler image pull policy                          | `IfNotPresent`                       |
-| `clusterFeatureEnabler.image.pullSecrets`              | Specify docker-registry secret names as an array                   | `[]`                                 |
-| `clusterFeatureEnabler.serviceAccount.create`          | Create serviceAccount for Cluster Feature Enabler                  | `true`                               |
-| `clusterFeatureEnabler.serviceAccount.name`            | Name of the serviceAccount for Cluster Feature Enabler             | `cluster-feature-enabler-sa`         |
-| `clusterFeatureEnabler.jobs.sidecarContainers.enabled` | Enable Sidecar Containers feature enabler job                      | `true`                               |
-| `clusterFeatureEnabler.jobs.sidecarContainers.name`    | Sidecar Containers feature enabler job name                        | `sidecar-containers-feature-enabler` |
-
 ### Vector parameters
 
-Vector observability agent for AGH3 captain, action-loop, and controller modules.
+Vector observability agent for AGH3 captain, action-loop, and controller modules.  
 ref: https://vector.dev
 
-| Name                      | Description                                                               | Value             |
-| ------------------------- | ------------------------------------------------------------------------- | ----------------- |
-| `vector.enabled`          | Enable Vector observability agent for captain, action-loop and controller | `false`           |
-| `vector.image.repository` | Vector image repository                                                   | `timberio/vector` |
-| `vector.image.tag`        | Vector image tag (immutable tags are recommended)                         | `latest-debian`   |
+| Name                        | Description                                                     | Value             |
+| ---------------------------| --------------------------------------------------------------- | ----------------- |
+| `vector.enabled`           | Enable Vector observability agent                               | `false`           |
+| `vector.image.repository`  | Vector image repository                                         | `timberio/vector` |
+| `vector.image.tag`         | Vector image tag (immutable tags are recommended)               | `latest-debian`   |
+
 
 ### Grafana parameters
 
-Grafana dashboard service for visualizing metrics, logs, and traces.
+Grafana dashboard service for visualizing metrics, logs, and traces.  
 ref: https://grafana.com/docs/grafana/latest/setup-grafana/installation/helm/
 
-| Name                                         | Description                                                          | Value                    |
-| -------------------------------------------- | -------------------------------------------------------------------- | ------------------------ |
-| `grafana.enabled`                            | Enable Grafana                                                       | `false`                  |
-| `grafana.image.repository`                   | Grafana image repository                                             | `docker/grafana/grafana` |
-| `grafana.initChownData.enabled`              | Enable init container for setting data directory ownership           | `false`                  |
-| `grafana.initChownData.image.repository`     | Init container image repository for setting data directory ownership | `docker/busybox`         |
-| `grafana.downloadDashboardsImage.repository` | Image repository used to download dashboards                         | `docker/curlimages/curl` |
-| `grafana.persistence.enabled`                | Enable Grafana persistence                                           | `true`                   |
-| `grafana.persistence.type`                   | Persistence type for Grafana (pvc or other supported types)          | `pvc`                    |
-| `grafana.fullnameOverride`                   | Fullname override for Grafana                                        | `grafana`                |
+| Name                                    | Description                                                         | Value                  |
+| --------------------------------------- | ------------------------------------------------------------------- | ---------------------- |
+| `grafana.enabled`                       | Enable Grafana                                                      | `false`                |
+| `grafana.image.repository`             | Grafana image repository                                            | `docker/grafana/grafana` |
+| `grafana.initChownData.image.repository`| Init container image for setting data ownership                     | `docker/busybox`       |
+| `grafana.downloadDashboardsImage.repository` | Image repository used to download dashboards                    | `docker/curlimages/curl` |
+| `grafana.persistence.enabled`          | Enable Grafana persistence                                          | `true`                 |
+| `grafana.persistence.type`             | Persistence type for Grafana                                        | `pvc`                  |
+
 
 ### Grafana Tempo parameters
 
-Grafana Tempo distributed tracing backend.
+Grafana Tempo distributed tracing backend.  
 ref: https://artifacthub.io/packages/helm/bitnami/grafana-tempo
 
-| Name                                               | Description                                     | Value                                        |
-| -------------------------------------------------- | ----------------------------------------------- | -------------------------------------------- |
-| `grafana-tempo.enabled`                            | Enable Grafana Tempo                            | `false`                                      |
-| `grafana-tempo.image.repository`                   | Tempo image repository                          | `docker/bitnamilegacy/grafana-tempo`         |
-| `grafana-tempo.tempo.image.repository`             | Tempo image repository                          | `docker/bitnamilegacy/grafana-tempo`         |
-| `grafana-tempo.tempo.traces.otlp.grpc`             | Enable gRPC for OTLP receiver                   | `true`                                       |
-| `grafana-tempo.queryFrontend.image.repository`     | Tempo query frontend image repository           | `docker/bitnamilegacy/grafana-tempo-query`   |
-| `grafana-tempo.vulture.image.repository`           | Tempo vulture image repository                  | `docker/bitnamilegacy/grafana-tempo-vulture` |
-| `grafana-tempo.volumePermissions.image.repository` | Image repository for setting volume permissions | `docker/bitnamilegacy/os-shell`              |
-| `grafana-tempo.volumePermissions.image.tag`        | Image tag for setting volume permissions        | `12-debian-12-r49`                           |
-| `grafana-tempo.ingester.resources.requests.memory` | Ingester memory requests                        | `512Mi`                                      |
-| `grafana-tempo.ingester.resources.requests.cpu`    | Ingester CPU requests                           | `250m`                                       |
-| `grafana-tempo.ingester.resources.limits.memory`   | Ingester memory limits                          | `2Gi`                                        |
-| `grafana-tempo.ingester.resources.limits.cpu`      | Ingester CPU limits                             | `1000m`                                      |
-| `grafana-tempo.memcached.enabled`                  | Enable memcached for Tempo                      | `false`                                      |
-| `grafana-tempo.externalMemcached.host`             | External memcached host address                 | `memcached.agh.svc.cluster.local`            |
-| `grafana-tempo.externalMemcached.port`             | External memcached port                         | `11211`                                      |
-| `grafana-tempo.fullnameOverride`                   | Fullname override for Grafana Tempo             | `grafana-tempo`                              |
+| Name                                                 | Description                                                                 | Value                                 |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| `grafana-tempo.enabled`                              | Enable Grafana Tempo                                                        | `false`                               |
+| `grafana-tempo.image.repository`                     | Tempo main image repository                                                 | `docker/bitnamilegacy/grafana-tempo`        |
+| `grafana-tempo.tempo.image.repository`               | Tempo OTLP image repository                                                 | `docker/bitnamilegacy/grafana-tempo`        |
+| `grafana-tempo.tempo.traces.otlp.grpc`               | Enable gRPC OTLP ingestion                                                  | `true`                                |
+| `grafana-tempo.queryFrontend.image.repository`       | Tempo query frontend image repository                                       | `docker/bitnamilegacy/grafana-tempo-query`  |
+| `grafana-tempo.vulture.image.repository`             | Tempo vulture image repository                                              | `docker/bitnamilegacy/grafana-tempo-vulture`|
+| `grafana-tempo.volumePermissions.image.repository`   | Image for volume permission setup                                           | `docker/bitnamilegacy/os-shell`             |
+| `grafana-tempo.volumePermissions.image.tag`          | Image tag for volume permission setup                                       | `12-debian-12-r49`                    |
+| `grafana-tempo.ingester.resources.requests.memory`   | Ingester memory requests                                                    | `"512Mi"`                             |
+| `grafana-tempo.ingester.resources.requests.cpu`      | Ingester CPU requests                                                       | `"250m"`                              |
+| `grafana-tempo.ingester.resources.limits.memory`     | Ingester memory limits                                                      | `"2Gi"`                               |
+| `grafana-tempo.ingester.resources.limits.cpu`        | Ingester CPU limits                                                         | `"1000m"`                             |
+| `grafana-tempo.memcached.enabled`                    | Enable internal Memcached                                                  | `false`                               |
+| `grafana-tempo.externalMemcached.host`               | External Memcached hostname                                                | `agh3-memcached.agh.svc.cluster.local` |
+| `grafana-tempo.externalMemcached.port`               | External Memcached port                                                    | `11211`                               |
+
 
 ### Grafana Loki parameters
 
-Grafana Loki log aggregation system.
+Grafana Loki log aggregation system.  
 ref: https://artifacthub.io/packages/helm/bitnami/grafana-loki
 
-| Name                                              | Description                                            | Value                               |
-| ------------------------------------------------- | ------------------------------------------------------ | ----------------------------------- |
-| `grafana-loki.enabled`                            | Enable Grafana Loki                                    | `false`                             |
-| `grafana-loki.loki.image.repository`              | Loki image repository                                  | `docker/bitnamilegacy/grafana-loki` |
-| `grafana-loki.loki.image.tag`                     | Loki image tag (immutable tags are recommended)        | `3.5.3-debian-12-r0`                |
-| `grafana-loki.compactor.extraArgs`                | Additional arguments for compactor                     | `["-config.expand-env=true"]`       |
-| `grafana-loki.distributor.extraArgs`              | Additional arguments for distributor                   | `["-config.expand-env=true"]`       |
-| `grafana-loki.ingester.extraArgs`                 | Additional arguments for ingester                      | `["-config.expand-env=true"]`       |
-| `grafana-loki.querier.extraArgs`                  | Additional arguments for querier                       | `["-config.expand-env=true"]`       |
-| `grafana-loki.queryFrontend.extraArgs`            | Additional arguments for query frontend                | `["-config.expand-env=true"]`       |
-| `grafana-loki.gateway.image.repository`           | Loki gateway image repository                          | `docker/bitnamilegacy/nginx`        |
-| `grafana-loki.gateway.image.tag`                  | Loki gateway image tag                                 | `1.29.0-debian-12-r5`               |
-| `grafana-loki.volumePermissions.image.repository` | Image repository for setting volume permissions        | `docker/bitnamilegacy/os-shell`     |
-| `grafana-loki.volumePermissions.image.tag`        | Image tag for setting volume permissions               | `12-debian-12-r49`                  |
-| `grafana-loki.grafanaalloy.enabled`               | Enable integration with Grafana Alloy                  | `false`                             |
-| `grafana-loki.memcachedchunks.enabled`            | Enable memcached for chunks caching                    | `false`                             |
-| `grafana-loki.externalMemcachedChunks.host`       | External memcached host address (IP or FQDN in string) | `memcached.agh.svc.cluster.local`   |
-| `grafana-loki.externalMemcachedChunks.port`       | External memcached port                                | `11211`                             |
-| `grafana-loki.memcachedfrontend.enabled`          | Enable memcached for frontend caching                  | `false`                             |
-| `grafana-loki.externalMemcachedFrontend.host`     | External memcached host address (IP or FQDN in string) | `memcached.agh.svc.cluster.local`   |
-| `grafana-loki.externalMemcachedFrontend.port`     | External memcached port                                | `11211`                             |
-| `grafana-loki.fullnameOverride`                   | Fullname override for Grafana Loki                     | `grafana-loki`                      |
+| Name                                                      | Description                                                             | Value                                  |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------- |
+| `grafana-loki.enabled`                                    | Enable Grafana Loki                                                     | `false`                                |
+| `grafana-loki.loki.image.repository`                      | Loki image repository                                                   | `docker/bitnamilegacy/grafana-loki`          |
+| `grafana-loki.loki.image.tag`                             | Loki image tag                                                          | `3.5.3-debian-12-r0`                   |
+| `grafana-loki.gateway.image.repository`                   | Loki gateway image repository                                           | `docker/bitnamilegacy/nginx`                 |
+| `grafana-loki.gateway.image.tag`                          | Loki gateway image tag                                                  | `1.29.0-debian-12-r5`                  |
+| `grafana-loki.volumePermissions.image.repository`         | Volume permission image repository                                      | `docker/bitnamilegacy/os-shell`              |
+| `grafana-loki.volumePermissions.image.tag`                | Volume permission image tag                                             | `12-debian-12-r49`                     |
+| `grafana-loki.grafanaalloy.enabled`                       | Enable Grafana Alloy integration                                        | `false`                                |
+| `grafana-loki.memcachedchunks.enabled`                    | Enable Memcached for chunks caching                                     | `false`                                |
+| `grafana-loki.externalMemcachedChunks.host`               | External Memcached chunks hostname                                      | `agh3-memcached.agh.svc.cluster.local` |
+| `grafana-loki.externalMemcachedChunks.port`               | External Memcached chunks port                                          | `11211`                                |
+| `grafana-loki.memcachedfrontend.enabled`                  | Enable Memcached for frontend caching                                   | `false`                                |
+| `grafana-loki.externalMemcachedFrontend.host`             | External Memcached frontend hostname                                    | `agh3-memcached.agh.svc.cluster.local` |
+| `grafana-loki.externalMemcachedFrontend.port`             | External Memcached frontend port                                        | `11211`                                |
+
 
 ### Memcached parameters
 
-Memcached distributed caching system.
+Memcached distributed caching system.  
 ref: https://artifacthub.io/packages/helm/bitnami/memcached
 
-| Name                         | Description                                          | Value                            |
-| ---------------------------- | ---------------------------------------------------- | -------------------------------- |
-| `memcached.enabled`          | Enable Memcached                                     | `false`                          |
-| `memcached.image.repository` | Memcached image repository                           | `docker/bitnamilegacy/memcached` |
-| `memcached.image.tag`        | Memcached image tag (immutable tags are recommended) | `1.6.39-debian-12-r0`            |
-| `memcached.fullnameOverride` | Fullname override for Memcached                      | `memcached`                      |
+| Name                           | Description                    | Value                                 |
+| ------------------------------ | ------------------------------ | ------------------------------------- |
+| `memcached.enabled`            | Enable Memcached               | `false`                               |
+| `memcached.image.repository`   | Memcached image repository     | `docker/bitnamilegacy/memcached`            |
+| `memcached.image.tag`          | Memcached image tag            | `1.6.39-debian-12-r0`                 |
+

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -444,7 +444,7 @@ minio:
   ##
   extraEnvVarsCM: agh-minio-cm
   persistence:
-    ## @param minio.persistence.mountPath Data volume mount path
+    ## @param persistence.mountPath Data volume mount path
     ##
     mountPath: /data
 ## @section Kueue parameters
@@ -507,7 +507,6 @@ redis:
 rabbitmq:
   ## @param rabbitmq.queueName Name of the RabbitMQ queue
   queueName: action_crd_result
-  ## @skip rabbitmq.loadDefinition
   loadDefinition:
     enabled: true
     existingSecret: agh-rabbitmq-secret
@@ -749,6 +748,8 @@ captain:
 ## Packet module for AGH3.
 ## descriptionEnd
 packet:
+  ## @param packet.secret.enabled Enable secrete generate for packet
+  ##
   secret:
     ## @param packet.secret.enabled Enable secret generate for packet
     ##
@@ -768,8 +769,10 @@ packet:
 ## AI Parser module for AGH3.
 ## @descriptionEnd
 parser:
+  ## @param parser.secret.minio.enabled Enable secrete generate for parser
+  ##
   secret:
-    ## @param parser.secret.enabled Enable secret generate for Parser
+    ## @param parser.secret.minio.enabled Enable secret generate for Parser
     ##
     enabled: true
     ## @param parser.secret.minio.enabled Enable secret generate for Minio
@@ -914,8 +917,6 @@ clusterFeatureEnabler:
     name: cluster-feature-enabler-sa
   jobs:
     ## @param clusterFeatureEnabler.jobs.sidecarContainers.enabled Enable Sidecar Containers feature enabler job
-    ## @param clusterFeatureEnabler.jobs.sidecarContainers.name Sidecar Containers feature enabler job name
-    ##
     sidecarContainers:
       name: sidecar-containers-feature-enabler
       enabled: true
@@ -949,7 +950,6 @@ grafana:
   ##
   image:
     repository: docker/grafana/grafana
-  ## @param grafana.initChownData.enabled Enable init container for setting data directory ownership
   ## @param grafana.initChownData.image.repository Init container image repository for setting data directory ownership
   ##
   initChownData:
@@ -979,8 +979,6 @@ grafana-tempo:
   ## @param grafana-tempo.enabled Enable Grafana Tempo
   ##
   enabled: false
-  ## @param grafana-tempo.image.repository Tempo image repository
-  ##
   image:
     repository: docker/bitnamilegacy/grafana-tempo
   tempo:
@@ -988,8 +986,6 @@ grafana-tempo:
     ##
     image:
       repository: docker/bitnamilegacy/grafana-tempo
-    ## @param grafana-tempo.tempo.traces.otlp.grpc Enable gRPC for OTLP receiver
-    ##
     traces:
       otlp:
         grpc: true
@@ -1005,7 +1001,6 @@ grafana-tempo:
       repository: docker/bitnamilegacy/grafana-tempo-vulture
   volumePermissions:
     ## @param grafana-tempo.volumePermissions.image.repository Image repository for setting volume permissions
-    ## @param grafana-tempo.volumePermissions.image.tag Image tag for setting volume permissions
     ##
     image:
       repository: docker/bitnamilegacy/os-shell
@@ -1024,8 +1019,6 @@ grafana-tempo:
         memory: "2Gi"
         cpu: "1000m"
   memcached:
-    ## @param grafana-tempo.memcached.enabled Enable memcached for Tempo
-    ##
     enabled: false
   externalMemcached:
     ## @param grafana-tempo.externalMemcached.host External memcached host address
@@ -1056,184 +1049,6 @@ grafana-loki:
     image:
       repository: docker/bitnamilegacy/grafana-loki
       tag: 3.5.3-debian-12-r0
-    overrideConfiguration:
-      ## @skip grafana-loki.loki.overrideConfiguration Storage configuration overrides
-      ##
-      storage_config:
-        aws:
-          endpoint: http://${MINIO_URL}
-          bucketnames: loki-data
-          access_key_id: ${MINIO_USERNAME}
-          secret_access_key: ${MINIO_PASSWORD}
-          region: us-east-1
-          s3forcepathstyle: true
-        tsdb_shipper:
-          active_index_directory: /loki/index
-          cache_location: /loki/index_cache
-          cache_ttl: 24h
-      schema_config:
-        ## @skip grafana-loki.loki.overrideConfiguration.schema_config.configs Loki schema configuration
-        ##
-        configs:
-          - from: 2020-07-01
-            store: tsdb
-            object_store: s3
-            schema: v13
-            index:
-              prefix: index_
-              period: 24h
-  compactor:
-    ## @param grafana-loki.compactor.extraArgs Additional arguments for compactor
-    ##
-    extraArgs:
-      - -config.expand-env=true
-    ## @skip grafana-loki.compactor.extraEnvVars Extra environment variables for compactor
-    ##
-    extraEnvVars:
-      - name: MINIO_URL
-        valueFrom:
-          secretKeyRef:
-            name: minio-secret
-            key: url
-      - name: MINIO_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-user
-      - name: MINIO_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-password
-    ## @skip grafana-loki.compactor.initContainers Init containers for compactor
-    ##
-    initContainers:
-      - name: minio-init
-        image: minio/mc:latest
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            echo "Waiting for MinIO to be ready..."
-            until mc alias set local http://$MINIO_URL $MINIO_USERNAME $MINIO_PASSWORD; do
-              echo "MinIO not ready, retrying..."
-              sleep 5
-            done
-
-            echo "Creating buckets..."
-            mc mb --ignore-existing local/loki-data
-
-            echo "Applying lifecycle policies..."
-            mc ilm add local/loki-data --expiry-days 90
-
-            echo "Setup completed!"
-        env:
-          - name: MINIO_URL
-            valueFrom:
-              secretKeyRef:
-                name: minio-secret
-                key: url
-          - name: MINIO_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: capt-minio-secret
-                key: capt-minio-user
-          - name: MINIO_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: capt-minio-secret
-                key: capt-minio-password
-  distributor:
-    ## @param grafana-loki.distributor.extraArgs Additional arguments for distributor
-    ##
-    extraArgs:
-      - -config.expand-env=true
-    ## @skip grafana-loki.distributor.extraEnvVars Extra environment variables for distributor
-    ##
-    extraEnvVars:
-      - name: MINIO_URL
-        valueFrom:
-          secretKeyRef:
-            name: minio-secret
-            key: url
-      - name: MINIO_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-user
-      - name: MINIO_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-password
-  ingester:
-    ## @param grafana-loki.ingester.extraArgs Additional arguments for ingester
-    ##
-    extraArgs:
-      - -config.expand-env=true
-    ## @skip grafana-loki.ingester.extraEnvVars Extra environment variables for ingester
-    ##
-    extraEnvVars:
-      - name: MINIO_URL
-        valueFrom:
-          secretKeyRef:
-            name: minio-secret
-            key: url
-      - name: MINIO_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-user
-      - name: MINIO_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-password
-  querier:
-    ## @param grafana-loki.querier.extraArgs Additional arguments for querier
-    ##
-    extraArgs:
-      - -config.expand-env=true
-    ## @skip grafana-loki.querier.extraEnvVars Extra environment variables for querier
-    ##
-    extraEnvVars:
-      - name: MINIO_URL
-        valueFrom:
-          secretKeyRef:
-            name: minio-secret
-            key: url
-      - name: MINIO_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-user
-      - name: MINIO_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-password
-  queryFrontend:
-    ## @param grafana-loki.queryFrontend.extraArgs Additional arguments for query frontend
-    ##
-    extraArgs:
-      - -config.expand-env=true
-    ## @skip grafana-loki.queryFrontend.extraEnvVars Extra environment variables for query frontend
-    ##
-    extraEnvVars:
-      - name: MINIO_URL
-        valueFrom:
-          secretKeyRef:
-            name: minio-secret
-            key: url
-      - name: MINIO_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-user
-      - name: MINIO_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: capt-minio-secret
-            key: capt-minio-password
   gateway:
     ## @param grafana-loki.gateway.image.repository Loki gateway image repository
     ## @param grafana-loki.gateway.image.tag Loki gateway image tag
@@ -1256,8 +1071,8 @@ grafana-loki:
   ##
   memcachedchunks:
     enabled: false
-  ## @param grafana-loki.externalMemcachedChunks.host External memcached host address (IP or FQDN in string)
-  ## @param grafana-loki.externalMemcachedChunks.port External memcached port
+  ## @param grafana-loki.externalMemcachedChunks.host External memcached host address
+  ## IP or FQDN in string
   ##
   externalMemcachedChunks:
     host: memcached.agh.svc.cluster.local
@@ -1266,8 +1081,8 @@ grafana-loki:
   ##
   memcachedfrontend:
     enabled: false
-  ## @param grafana-loki.externalMemcachedFrontend.host External memcached host address (IP or FQDN in string)
-  ## @param grafana-loki.externalMemcachedFrontend.port External memcached port
+  ## @param grafana-loki.externalMemcachedFrontend.host External memcached host address
+  ## IP or FQDN in string
   ##
   externalMemcachedFrontend:
     host: memcached.agh.svc.cluster.local
@@ -1282,12 +1097,7 @@ grafana-loki:
 ## @descriptionEnd
 ##
 memcached:
-  ## @param memcached.enabled Enable Memcached
-  ## @description Enable Memcached for caching
   enabled: false
-  ## @param memcached.image.repository Memcached image repository
-  ## @param memcached.image.tag Memcached image tag (immutable tags are recommended)
-  ##
   image:
     repository: docker/bitnamilegacy/memcached
     tag: 1.6.39-debian-12-r0


### PR DESCRIPTION
Reverts Leukocyte-Lab/helm-charts#405

## Summary by Sourcery

Revert the addition of MinIO-backed storage for Loki and restore the original chart configuration, including version rollbacks and cleanup of related documentation and CI steps.

Bug Fixes:
- Remove custom Grafana Loki S3 storage configuration and MinIO init containers
- Revert S3 override and extraArgs sections for distributor, compactor, ingester, querier, and query frontend

Enhancements:
- Rollback container image tags for PostgreSQL, MinIO client, Captain, Controller, UI, and Report to previous versions

CI:
- Remove the GitHub Actions chart-testing step that enabled observability and storage-system-only mode

Chores:
- Remove deprecated parameter sections for security, CRDs, Kueue, Action Loop, Packet, Parser, and Cluster Feature Enabler from README and values
- Simplify values.yaml and README formatting by cleaning up parameter blocks