### PR TITLE
fix: attach new policy and detach old one

### DIFF
--- a/charts/agh3/templates/minio/agh-minio-users-secret.yml
+++ b/charts/agh3/templates/minio/agh-minio-users-secret.yml
@@ -68,7 +68,7 @@ stringData:
     {{- with index .Values.minio.provisioning.policies 1 }}
     policies={{ .name }}
     {{- end }}
-    setPolicies=false
+    setPolicies=true
   {{ .Values.packet.secret.minio.user }}: |
     username={{ .Values.packet.secret.minio.user }}
     password={{

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -399,7 +399,7 @@ minio:
               - "s3:GetBucketLocation"
               - "s3:ListBucket"
               - "s3:GetObject"
-      - name: agh-parser-policy
+      - name: agh-ai-policy
         statements:
           - effect: "Allow"
             resources:


### PR DESCRIPTION
## Summary by Sourcery

Enable MinIO policy assignment and switch to the new AI policy

Bug Fixes:
- Turn on policy attachment by setting setPolicies to true
- Replace the old agh-parser-policy with the new agh-ai-policy