### PR TITLE
feat: remove minio bucket check of captain init container

### DIFF
--- a/charts/agh3/templates/_helpers.tpl
+++ b/charts/agh3/templates/_helpers.tpl
@@ -197,13 +197,6 @@ Return the proper rabbitmq-test-client image name
 {{- end }}
 
 {{/*
-  Return the proper minio-bucket-test-client image name
-*/}}
-{{- define "minio-bucket-test-client.image" -}}
-{{- include "common.images.image" (dict "imageRoot" .Values.minio.helpers.bucket.image "global" .Values.global) }}
-{{- end }}
-
-{{/*
 Return the proper kueue-initialize image name
 */}}
 {{- define "kueue-initialize.image" -}}

--- a/charts/agh3/templates/captain/captain-deployment.yml
+++ b/charts/agh3/templates/captain/captain-deployment.yml
@@ -49,29 +49,6 @@ spec:
               "-c",
               "until curl http://minio.$(NAMESPACE).svc.cluster.local:9000; do echo $(date) waiting... && sleep 1; done;"
             ]
-        - name: captain-init-minio-bucket-intelli-bridge
-          image: {{ include "minio-bucket-test-client.image" . }}
-          env:
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MINIO_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.captain.secret.minio.secretName }}
-                  key: capt-minio-user
-            - name: MINIO_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.captain.secret.minio.secretName }}
-                  key: capt-minio-password
-          command:
-            [
-              "sh",
-              "-c",
-              "until mc alias set m http://minio.$(NAMESPACE).svc.cluster.local:9000 $MINIO_USER $MINIO_PASSWORD && mc ls m/intelli-bridge; do echo $(date) waiting... && sleep 5; done;"
-            ]
         - name: captain-init-rabbitmq
           image: {{ include "rabbitmq-test-client.image" . }}
           env:

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -357,18 +357,6 @@ minio:
         tag: 8.15.0
         pullPolicy: IfNotPresent
         pullSecrets: []
-    ## Minio Bucket Test image
-    ## @param minio.helpers.bucket.image.repository Minio Bucket Test image repository
-    ## @param minio.helpers.bucket.image.tag Minio Bucket Test image tag(immutable tags are recommended)
-    ## @param minio.helpers.bucket.image.pullPolicy Minio Bucket Test image pull policy
-    ## @param minio.helpers.bucket.image.pullSecrets Specify docker-registry secret names as an array
-    ##
-    bucket:
-      image:
-        repository: docker/minio/mc
-        tag: RELEASE.2025-07-16T15-35-03Z
-        pullPolicy: IfNotPresent
-        pullSecrets: []
   ## @param minio.auth.rootUser Internal database root user
   ## @param minio.auth.rootPassword Internal database root password
   ##


### PR DESCRIPTION
Now defense device seeding is using updater, there's no need to verify minio bucket on boot

## Summary by Sourcery

Remove the obsolete minio bucket verification init container and related configurations from the captain Helm chart, as device seeding is now handled by the updater.

Enhancements:
- Remove the minio bucket readiness check init container from the captain deployment
- Delete the minio bucket test image configuration from values.yaml and its helper template