### PR TITLE
build: Release chart/agh3 `v3.12.18`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.12.17
+version: 3.12.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v3.11.4"
+appVersion: "v3.11.5"
 dependencies:
   - name: postgresql
     version: 12.1.2

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -628,7 +628,7 @@ actionLoop:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-actionloop
-    tag: v1.15.12
+    tag: v1.15.13
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param actionLoop.serviceAccount.create Create serviceAccount for Action Loop
@@ -658,7 +658,7 @@ captain:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-captain
-    tag: v1.15.12
+    tag: v1.15.13
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param captain.secret.enabled Enable secret generate for Captain
@@ -857,7 +857,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.13.16
+    tag: v1.13.17
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.12.18`
- App Version: `3.11.5`
  - ActionLoop: `v1.15.13`
  - Captain: `v1.15.13`
  - Controller: `v1.3.1`
  - UI: `v1.13.17`
  - Report: `v1.2.6`

## Summary by Sourcery

Release chart agh3 version 3.12.18 with updated app and container image versions

Enhancements:
- Bump chart version to 3.12.18 and app version to v3.11.5
- Update ActionLoop and Captain containers to v1.15.13
- Update UI container image to v1.13.17