### PR TITLE
feat: add editor flag to deny access to editor route

### DIFF
--- a/charts/agh3/templates/base/agh-ingressroute.yml
+++ b/charts/agh3/templates/base/agh-ingressroute.yml
@@ -15,6 +15,16 @@ spec:
           name: ui
           port: 80
     {{- end }}
+    {{- if .Values.ui.enabled }}
+    - kind: Rule
+      match: {{ printf "%s%s" "(PathPrefix(`/api/static`) || PathPrefix(`/api/template`))" (empty .Values.ingress.host | ternary "" (print " && Host(`" (.Values.ingress.host) "`)" )) }}
+      middlewares:
+        - name: https-redirectscheme
+      services:
+        - kind: Service
+          name: ui
+          port: 80
+    {{- end }}
     {{- if .Values.captain.enabled }}
     {{- if not .Values.captain.editor.enabled }}
     - kind: Rule
@@ -33,16 +43,6 @@ spec:
         - kind: Service
           name: captain
           port: 8080
-    {{- end }}
-    {{- if .Values.ui.enabled }}
-    - kind: Rule
-      match: {{ printf "%s%s" "(PathPrefix(`/api/static`) || PathPrefix(`/api/template`))" (empty .Values.ingress.host | ternary "" (print " && Host(`" (.Values.ingress.host) "`)" )) }}
-      middlewares:
-        - name: https-redirectscheme
-      services:
-        - kind: Service
-          name: ui
-          port: 80
     {{- end }}
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/charts/agh3/templates/base/agh-ingressroute.yml
+++ b/charts/agh3/templates/base/agh-ingressroute.yml
@@ -16,6 +16,17 @@ spec:
           port: 80
     {{- end }}
     {{- if .Values.captain.enabled }}
+    {{- if not .Values.captain.editor.enabled }}
+    - kind: Rule
+      match: {{ printf "%s%s" "PathPrefix(`/api/editor`)" (empty .Values.ingress.host | ternary "" (print " && Host(`" (.Values.ingress.host) "`)" )) }}
+      priority: 100
+      middlewares:
+        - name: force-404-middleware
+      services:
+        - kind: Service
+          name: captain
+          port: 8080
+    {{- end }}
     - kind: Rule
       match: {{ printf "%s%s" "PathPrefix(`/api`)" (empty .Values.ingress.host | ternary "" (print " && Host(`" (.Values.ingress.host) "`)" )) }}
       services:
@@ -42,4 +53,12 @@ spec:
   redirectScheme:
     scheme: https
     permanent: true
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: force-404-middleware
+spec:
+  replacePath:
+    path: /404
 {{- end }}

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -647,6 +647,10 @@ captain:
   ## @param captain.enabled Enable Captain module
   ##
   enabled: true
+  ## @param captain.editor.enabled Enable editor module
+  ##
+  editor:
+    enabled: true
   ## @param captain.image.repository Captain image repository
   ## @param captain.image.tag Captain image tag (immutable tags are recommended)
   ## @param captain.image.pullPolicy Captain image pull policy

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -650,7 +650,7 @@ captain:
   ## @param captain.editor.enabled Enable editor module
   ##
   editor:
-    enabled: true
+    enabled: false
   ## @param captain.image.repository Captain image repository
   ## @param captain.image.tag Captain image tag (immutable tags are recommended)
   ## @param captain.image.pullPolicy Captain image pull policy


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configuration flag to disable the editor module and enforce a 404 response for `/api/editor` requests by updating the ingress route and adding a dedicated middleware.

New Features:
- Add captain.editor.enabled flag to control access to the editor route

Enhancements:
- Add ingress rule to intercept `/api/editor` and apply a force-404 middleware when the editor route is disabled
- Define `force-404-middleware` to rewrite intercepted requests to `/404`
- Adjust ingress rule order to ensure UI static/template and general API routes maintain correct precedence