### PR TITLE
build: Release chart/agh3 `v3.14.15`

### DIFF
--- a/charts/agh3/Chart.yaml
+++ b/charts/agh3/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.14
+version: 3.14.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/agh3/values.yaml
+++ b/charts/agh3/values.yaml
@@ -885,7 +885,7 @@ ui:
   ##
   image:
     repository: leukocyte-lab/argushack3/ctr-ui
-    tag: v1.15.31
+    tag: v1.15.32
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param ui.extraEnv UI additional environment variables


### PR DESCRIPTION
- Chart Version: `3.14.15`
- App Version: `3.13.0`
  - ActionLoop: `v1.17.8`
  - Captain: `v1.17.8`
  - Captain Migration: `v1.17.8`
  - Controller: `v1.3.2`
  - UI: `v1.15.32`
  - Report: `v1.3.5`

## Summary by Sourcery

Bump the agh3 Helm chart and UI component versions for a new release.

Enhancements:
- Update the UI container image tag to v1.15.32 in the agh3 values configuration.

Build:
- Increment agh3 chart version to 3.14.15 for the new release.